### PR TITLE
Add PR merged webhook: pull from default branch and restart server

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,15 @@ Key configuration areas:
 
 - Git platform settings (GitHub, GitLab, BitBucket)
 - AI agent configuration
-- Bot identity (name, email)
+- Bot identity (name, email, default branch)
 - Webhook settings
+
+### PR merged webhook and restart
+
+When a pull request is merged (GitHub `pull_request` event with `action: closed` and `merged: true`), the bot runs `git pull origin <default_branch>` in its working directory and then exits with code 0 so that a process manager can restart it.
+
+- **Console**: Run the bot under a supervisor that restarts on exit (e.g. systemd, or a shell loop like `while true; do python -m coddy.main; done`).
+- **Docker**: Use a restart policy (e.g. `restart: unless-stopped` in Compose) so the container restarts after the bot exits and picks up the latest code.
 
 ## Development
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,6 +6,7 @@ bot:
   email: "bot@coddy.dev"
   git_platform: "github"  # github, gitlab, bitbucket
   repository: "owner/repo"
+  default_branch: "main"   # used for git pull on PR merge and for PR base
   webhook_secret: "your-webhook-secret-here"
   ai_agent: "cursor_cli"
 

--- a/docs/issue-pr-merged-webhook-short.md
+++ b/docs/issue-pr-merged-webhook-short.md
@@ -1,0 +1,27 @@
+# Title (for GitHub/GitLab issue)
+
+**Add PR merged webhook: pull from default branch and restart server**
+
+---
+
+# Description (paste into issue body)
+
+## Goal
+
+- Handle webhooks that indicate a **PR was merged**. On merge: **pull** from the default branch and **restart** the webhook/API server (works in console and Docker).
+- Add a **config option for the default branch** and use it instead of determining it from the API where possible.
+- Optionally: run the webhook server with **uvicorn** so `--reload` is available in development.
+
+## Tasks
+
+- [ ] Handle "PR merged" events (e.g. GitHub `pull_request` with `action: closed` and `merged: true`).
+- [ ] On merge: run `git pull origin <default_branch>` in the bot working directory, then restart the server (document behavior for console and Docker).
+- [ ] Add config option for default branch (e.g. `bot.default_branch: "main"`); use it for pull and for PR/branch operations; remove or reduce `get_default_branch` usage where redundant.
+- [ ] (Optional) Add uvicorn, serve webhook app with it, support `--reload` for development.
+- [ ] Update tests and docs (config example, README).
+
+## References
+
+- Current webhook: `src/coddy/webhook/server.py`, `handlers.py`
+- Config: `src/coddy/config.py`; default branch: `adapters/github.py` `get_default_branch`, `services/issue_processor.py`
+- Full spec: `docs/issue-pr-merged-webhook-and-restart.md`

--- a/src/coddy/adapters/base.py
+++ b/src/coddy/adapters/base.py
@@ -78,12 +78,13 @@ class GitPlatformAdapter(ABC):
         """
         raise NotImplementedError
 
-    def create_branch(self, repo: str, branch_name: str) -> None:
+    def create_branch(self, repo: str, branch_name: str, base_branch: str | None = None) -> None:
         """Create a branch from the default branch HEAD (e.g. main).
 
         Args:
             repo: Repository in format owner/repo
             branch_name: New branch name (e.g. 1-implement-get-issue-assignees)
+            base_branch: Optional default branch name; if not set, obtained from API
         """
         raise NotImplementedError
 

--- a/src/coddy/adapters/github.py
+++ b/src/coddy/adapters/github.py
@@ -162,9 +162,9 @@ class GitHubAdapter(GitPlatformAdapter):
         resp = self._request("GET", f"/repos/{repo}")
         return resp.json().get("default_branch", "main")
 
-    def create_branch(self, repo: str, branch_name: str) -> None:
+    def create_branch(self, repo: str, branch_name: str, base_branch: str | None = None) -> None:
         """Create a branch from the default branch HEAD."""
-        default_branch = self.get_default_branch(repo)
+        default_branch = base_branch or self.get_default_branch(repo)
         ref_path = f"/repos/{repo}/git/ref/heads/{default_branch}"
         ref_resp = self._request("GET", ref_path)
         ref_data = ref_resp.json()

--- a/src/coddy/config.py
+++ b/src/coddy/config.py
@@ -38,6 +38,7 @@ class BotConfig(BaseSettings):
     email: str = Field(default="bot@coddy.dev", description="Bot email for commits")
     git_platform: str = Field(default="github", description="github, gitlab, bitbucket")
     repository: str = Field(default="owner/repo", description="Target repo e.g. EvilFreelancer/coddy")
+    default_branch: str = Field(default="main", description="Default branch for pull and PR base (e.g. main)")
     github_username: str | None = Field(
         default=None, description="Bot GitHub login (to skip own comments when polling)"
     )

--- a/src/coddy/main.py
+++ b/src/coddy/main.py
@@ -122,6 +122,7 @@ def run(config: AppConfig) -> None:
             bot_username=getattr(config.bot, "github_username", None),
             bot_name=config.bot.name,
             bot_email=config.bot.email,
+            default_branch=config.bot.default_branch,
             log=log,
         )
 

--- a/src/coddy/services/git_runner.py
+++ b/src/coddy/services/git_runner.py
@@ -42,6 +42,30 @@ def branch_name_from_issue(issue_number: int, title: str) -> str:
     return f"{issue_number}-{slug}" if slug else str(issue_number)
 
 
+def run_git_pull(
+    branch: str,
+    repo_dir: Path | None = None,
+    log: logging.Logger | None = None,
+) -> None:
+    """Run git pull origin <branch> in the repository.
+
+    Used after a PR is merged to update the local default branch before
+    restarting the server.
+
+    Args:
+        branch: Branch to pull (e.g. main)
+        repo_dir: Repository root; default current directory
+        log: Optional logger
+
+    Raises:
+        GitRunnerError: If git pull fails
+    """
+    cwd = Path(repo_dir) if repo_dir is not None else Path.cwd()
+    _run_git(["pull", "origin", branch], cwd=cwd, log=log)
+    if log:
+        log.info("Pulled origin/%s", branch)
+
+
 def fetch_and_checkout_branch(
     branch_name: str,
     repo_dir: Path | None = None,

--- a/src/coddy/services/issue_processor.py
+++ b/src/coddy/services/issue_processor.py
@@ -32,6 +32,7 @@ def process_one_issue(
     bot_username: str | None = None,
     bot_name: str | None = None,
     bot_email: str | None = None,
+    default_branch: str | None = None,
     poll_interval: int = POLL_INTERVAL_SECONDS,
     log: logging.Logger | None = None,
 ) -> None:
@@ -53,7 +54,7 @@ def process_one_issue(
     logger.info("Creating or reusing branch %s for issue #%s", branch_name, issue.number)
 
     try:
-        adapter.create_branch(repo, branch_name)
+        adapter.create_branch(repo, branch_name, base_branch=default_branch)
     except GitPlatformError as e:
         err_msg = str(e).lower()
         if "already exists" in err_msg or "422" in err_msg:
@@ -98,7 +99,7 @@ def process_one_issue(
                     except Exception as e:
                         logger.warning("Failed to commit/push: %s", e)
                 try:
-                    base_branch = adapter.get_default_branch(repo)
+                    base_branch = default_branch or adapter.get_default_branch(repo)
                     adapter.create_pr(
                         repo,
                         title=issue.title,

--- a/tests/test_git_runner.py
+++ b/tests/test_git_runner.py
@@ -1,6 +1,15 @@
-"""Tests for git_runner (branch name, fetch/checkout)."""
+"""Tests for git_runner (branch name, fetch/checkout, pull)."""
 
-from coddy.services.git_runner import branch_name_from_issue
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from coddy.services.git_runner import (
+    GitRunnerError,
+    branch_name_from_issue,
+    run_git_pull,
+)
 
 
 def test_branch_name_from_issue() -> None:
@@ -16,3 +25,26 @@ def test_branch_name_from_issue_long_title() -> None:
     name = branch_name_from_issue(1, long_title)
     assert name.startswith("1-")
     assert len(name) <= 43
+
+
+def test_run_git_pull_success() -> None:
+    """run_git_pull runs git pull origin <branch> in repo_dir."""
+    with patch("coddy.services.git_runner._run_git") as mock_run:
+        run_git_pull("main", repo_dir=Path("/tmp/repo"), log=None)
+    mock_run.assert_called_once_with(["pull", "origin", "main"], cwd=Path("/tmp/repo"), log=None)
+
+
+def test_run_git_pull_uses_cwd_when_no_repo_dir() -> None:
+    """run_git_pull uses Path.cwd() when repo_dir is None."""
+    with patch("coddy.services.git_runner._run_git") as mock_run:
+        run_git_pull("main", log=None)
+    assert mock_run.call_count == 1
+    assert mock_run.call_args[0][0] == ["pull", "origin", "main"]
+    assert mock_run.call_args[1]["cwd"] == Path.cwd()
+
+
+def test_run_git_pull_raises_on_failure() -> None:
+    """run_git_pull propagates GitRunnerError from _run_git."""
+    with patch("coddy.services.git_runner._run_git", side_effect=GitRunnerError("pull failed")):
+        with pytest.raises(GitRunnerError, match="pull failed"):
+            run_git_pull("main", repo_dir=Path("/tmp/repo"))

--- a/tests/test_webhook_handlers.py
+++ b/tests/test_webhook_handlers.py
@@ -1,0 +1,102 @@
+"""Tests for webhook handlers (PR merged, review comment)."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from coddy.webhook.handlers import handle_github_event
+
+
+@pytest.fixture
+def config_pr_merged() -> "object":
+    """Config with github platform and default_branch."""
+    config = type("Config", (), {})()
+    config.bot = type("Bot", (), {})()
+    config.bot.git_platform = "github"
+    config.bot.repository = "owner/repo"
+    config.bot.default_branch = "main"
+    config.ai_agents = {"cursor_cli": type("CLI", (), {"working_directory": "."})()}
+    return config
+
+
+def test_handle_pr_merged_pulls_and_exits(config_pr_merged: "object") -> None:
+    """On pull_request closed+merged, run_git_pull is called and sys.exit(0)."""
+    payload = {
+        "action": "closed",
+        "pull_request": {"merged": True, "number": 1},
+        "repository": {"full_name": "owner/repo"},
+    }
+    with patch("coddy.services.git_runner.run_git_pull", create=True) as mock_pull:
+        with patch("coddy.webhook.handlers.sys.exit") as mock_exit:
+            mock_exit.side_effect = SystemExit(0)
+            with pytest.raises(SystemExit, match="0"):
+                handle_github_event(config_pr_merged, "pull_request", payload)
+    mock_pull.assert_called_once()
+    call_kw = mock_pull.call_args[1]
+    assert call_kw["log"] is not None
+    mock_exit.assert_called_once_with(0)
+
+
+def test_handle_pr_merged_ignores_when_not_merged(config_pr_merged: "object") -> None:
+    """pull_request closed but not merged does nothing."""
+    payload = {
+        "action": "closed",
+        "pull_request": {"merged": False},
+        "repository": {"full_name": "owner/repo"},
+    }
+    with patch("coddy.services.git_runner.run_git_pull", create=True) as mock_pull:
+        with patch("coddy.webhook.handlers.sys.exit") as mock_exit:
+            handle_github_event(config_pr_merged, "pull_request", payload)
+    mock_pull.assert_not_called()
+    mock_exit.assert_not_called()
+
+
+def test_handle_pr_merged_ignores_other_repo(config_pr_merged: "object") -> None:
+    """pull_request merged for another repo does nothing."""
+    payload = {
+        "action": "closed",
+        "pull_request": {"merged": True},
+        "repository": {"full_name": "other/repo"},
+    }
+    with patch("coddy.services.git_runner.run_git_pull", create=True) as mock_pull:
+        with patch("coddy.webhook.handlers.sys.exit") as mock_exit:
+            handle_github_event(config_pr_merged, "pull_request", payload)
+    mock_pull.assert_not_called()
+    mock_exit.assert_not_called()
+
+
+def test_handle_pr_merged_uses_repo_dir_when_passed(config_pr_merged: "object") -> None:
+    """When repo_dir is passed, run_git_pull is called with that path."""
+    payload = {
+        "action": "closed",
+        "pull_request": {"merged": True},
+        "repository": {"full_name": "owner/repo"},
+    }
+    custom_dir = Path("/tmp/bot-repo")
+    with patch("coddy.services.git_runner.run_git_pull", create=True) as mock_pull:
+        with patch("coddy.webhook.handlers.sys.exit", side_effect=SystemExit(0)):
+            with pytest.raises(SystemExit):
+                handle_github_event(
+                    config_pr_merged,
+                    "pull_request",
+                    payload,
+                    repo_dir=custom_dir,
+                )
+    mock_pull.assert_called_once()
+    assert mock_pull.call_args[1]["repo_dir"] == custom_dir
+
+
+def test_handle_pr_merged_no_exit_on_pull_failure(config_pr_merged: "object") -> None:
+    """When run_git_pull raises, we do not call sys.exit."""
+    from coddy.services.git_runner import GitRunnerError
+
+    payload = {
+        "action": "closed",
+        "pull_request": {"merged": True},
+        "repository": {"full_name": "owner/repo"},
+    }
+    with patch("coddy.services.git_runner.run_git_pull", create=True, side_effect=GitRunnerError("pull failed")):
+        with patch("coddy.webhook.handlers.sys.exit") as mock_exit:
+            handle_github_event(config_pr_merged, "pull_request", payload)
+    mock_exit.assert_not_called()


### PR DESCRIPTION
# PR: Add PR merged webhook - pull from default branch and restart server

Closes #3.

## What was done

- **PR merged webhook**: The bot now handles GitHub `pull_request` events with `action: closed` and `merged: true`. On merge it runs `git pull origin <default_branch>` in the bot working directory and then exits with code 0 so a process manager (systemd, Docker restart policy, or a shell loop) can restart the server and pick up the new code.

- **Default branch config**: Added `bot.default_branch` (e.g. `main`) in config and `config.example.yaml`. It is used for the pull on PR merge and for PR/branch operations. The GitHub adapter's `create_branch` now accepts an optional `base_branch` argument; when provided, the adapter skips the repo API call to get the default branch. The issue processor uses `config.bot.default_branch` when creating branches and PRs, falling back to `adapter.get_default_branch(repo)` when not set.

- **Git pull helper**: Added `run_git_pull(branch, repo_dir, log)` in `coddy.services.git_runner` to run `git pull origin <branch>` in the given directory.

- **Docs**: Updated `config.example.yaml` with `default_branch`. In README, added a short section "PR merged webhook and restart" describing that the bot exits after pull so a supervisor can restart it, with notes for console (systemd or shell loop) and Docker (restart policy).

- **Tests**: Added tests for `run_git_pull` in `tests/test_git_runner.py`; tests for PR-merged handler in `tests/test_webhook_handlers.py` (pull + exit, ignore when not merged / other repo, repo_dir passed, no exit on pull failure); and `test_create_branch_with_base_branch_skips_repo_api` in `tests/test_adapters_github.py`.

## How to test

1. **Config**: Set `bot.default_branch` in `config.yaml` (e.g. `main`). Run `python -m coddy.main --check` and confirm it loads.

2. **PR merged webhook**: Send a POST to the webhook path with `X-GitHub-Event: pull_request` and a payload with `action: "closed"`, `pull_request.merged: true`, and `repository.full_name` matching `bot.repository`. The bot should run `git pull origin <default_branch>` in its working directory and then exit with code 0. If the repo does not match or the PR is not merged, nothing happens.

3. **Unit tests**: Run `pytest tests/ -v` (with `PYTHONPATH=src` if needed). All tests, including the new ones for handlers, git_runner, and adapter, should pass.

4. **Lint**: Run `ruff check .` and `ruff format .`; both should pass.

## Reference

Issue #3: Add PR merged webhook - pull from default branch and restart server.