### PR TITLE
Лейбл review у issue если PR готов

### DIFF
--- a/src/coddy/webhook/handlers.py
+++ b/src/coddy/webhook/handlers.py
@@ -1,8 +1,7 @@
-"""
-Handle GitHub webhook events (e.g. PR review comment, PR merged).
+"""Handle GitHub webhook events (e.g. PR review comment, PR merged).
 
-Parses payload and delegates to services (review handler) or runs git pull
-and restarts on PR merged.
+Parses payload and delegates to services (review handler) or runs git
+pull and restarts on PR merged.
 """
 
 import logging
@@ -101,8 +100,7 @@ def handle_github_event(
     repo_dir: Path | None = None,
     log: logging.Logger | None = None,
 ) -> None:
-    """
-    Handle a GitHub webhook event.
+    """Handle a GitHub webhook event.
 
     Supported events:
     - pull_request (action=closed, merged=true): git pull from default branch, then exit 0 to allow restart.

--- a/tests/test_adapters_github.py
+++ b/tests/test_adapters_github.py
@@ -211,7 +211,8 @@ def test_create_branch_success(adapter: GitHubAdapter) -> None:
 
 
 def test_create_branch_with_base_branch_skips_repo_api(adapter: GitHubAdapter) -> None:
-    """create_branch with base_branch uses it and does not call get repo API."""
+    """create_branch with base_branch uses it and does not call get repo
+    API."""
     ref_data = {"object": {"sha": "def456"}}
 
     def side_effect(method, url, **kwargs):

--- a/tests/test_issue_processor.py
+++ b/tests/test_issue_processor.py
@@ -1,0 +1,52 @@
+"""Tests for issue processor (process_one_issue)."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from coddy.agents.base import SufficiencyResult
+from coddy.models import Issue
+from coddy.services.issue_processor import process_one_issue
+
+
+def test_process_one_issue_sets_review_label_after_pr_created(tmp_path: Path) -> None:
+    """When agent completes and returns PR body, issue gets label 'review' after create_pr."""
+    dt = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+    issue = Issue(6, "Add review label", "Body", "user", [], "open", dt, dt)
+
+    adapter = Mock()
+    adapter.get_issue.return_value = issue
+    adapter.get_issue_comments.return_value = []
+    adapter.get_default_branch.return_value = "main"
+    adapter.create_pr.return_value = None
+
+    agent = Mock()
+    agent.evaluate_sufficiency.return_value = SufficiencyResult(sufficient=True)
+    agent.generate_code.return_value = "PR description body"
+
+    with (
+        patch(
+            "coddy.services.issue_processor.fetch_and_checkout_branch",
+        ),
+        patch(
+            "coddy.services.issue_processor.commit_all_and_push",
+        ),
+    ):
+        process_one_issue(
+            adapter,
+            agent,
+            issue,
+            "owner/repo",
+            repo_dir=tmp_path,
+            bot_name="Bot",
+            bot_email="bot@example.com",
+            default_branch="main",
+        )
+
+    adapter.create_pr.assert_called_once()
+    set_labels_calls = [c for c in adapter.set_issue_labels.call_args_list]
+    review_calls = [c for c in set_labels_calls if c[0][2] == ["review"]]
+    assert len(review_calls) == 1, "set_issue_labels should be called with ['review'] after PR creation"
+    assert review_calls[0][0][0] == "owner/repo"
+    assert review_calls[0][0][1] == 6
+    assert review_calls[0][0][2] == ["review"]

--- a/tests/test_webhook_handlers.py
+++ b/tests/test_webhook_handlers.py
@@ -21,7 +21,8 @@ def config_pr_merged() -> "object":
 
 
 def test_handle_pr_merged_pulls_and_exits(config_pr_merged: "object") -> None:
-    """On pull_request closed+merged, run_git_pull is called and sys.exit(0)."""
+    """On pull_request closed+merged, run_git_pull is called and
+    sys.exit(0)."""
     payload = {
         "action": "closed",
         "pull_request": {"merged": True, "number": 1},


### PR DESCRIPTION
# PR #6: Label "review" on issue when PR is ready

## What was done

- The behaviour required by the issue was already implemented in `src/coddy/services/issue_processor.py`: when the agent finishes the task and a pull request is created, the issue gets the label `review` (see `adapter.set_issue_labels(repo, issue.number, ["review"])` after `adapter.create_pr(...)`).
- A unit test was added in `tests/test_issue_processor.py` to verify this behaviour: `test_process_one_issue_sets_review_label_after_pr_created` checks that after the agent returns a PR body and the adapter creates the PR, `set_issue_labels` is called with `["review"]` for the same issue.

## How to test

1. Run the new test:
   ```bash
   pytest tests/test_issue_processor.py::test_process_one_issue_sets_review_label_after_pr_created -v
   ```
2. Run the full test suite:
   ```bash
   pytest tests/ -v
   ```
3. Optionally run the app on an issue and confirm that when a PR is created, the issue label is set to `review` in the Git hosting UI.

## Reference

Closes #6.