### PR TITLE
Draft folder for draft PRs

### DIFF
--- a/coddy/observer/adapters/github.py
+++ b/coddy/observer/adapters/github.py
@@ -56,6 +56,7 @@ def _pr_from_api(data: Dict[str, Any]) -> PR:
         state=data.get("state", "open"),
         html_url=data.get("html_url"),
         merged_at=merged_at,
+        draft=bool(data.get("draft", False)),
     )
 
 

--- a/coddy/observer/models/pr.py
+++ b/coddy/observer/models/pr.py
@@ -16,3 +16,4 @@ class PR(BaseModel):
     state: str
     html_url: str | None = None
     merged_at: datetime | None = Field(default=None, description="When PR was merged; None if not merged")
+    draft: bool = Field(default=False, description="Whether the PR is in draft mode")

--- a/coddy/observer/sync.py
+++ b/coddy/observer/sync.py
@@ -20,9 +20,11 @@ from coddy.services.store import (
 
 
 def _pr_status_from_api(pr: Any) -> str:
-    """Map platform PR state and merged_at to store status (open, merged,
-    rejected)."""
+    """Map platform PR state, draft flag and merged_at to store status
+    (open, merged, rejected, draft)."""
     if getattr(pr, "state", "open") == "open":
+        if getattr(pr, "draft", False):
+            return "draft"
         return "open"
     if getattr(pr, "merged_at", None):
         return "merged"

--- a/coddy/observer/webhook/events/pull_request.py
+++ b/coddy/observer/webhook/events/pull_request.py
@@ -30,6 +30,22 @@ class PRMerged(BaseModel):
     pr_number: int
 
 
+class PRConvertedToDraft(BaseModel):
+    """PR converted to draft (pull_request webhook,
+    action=converted_to_draft)."""
+
+    repo: str
+    pr_number: int
+
+
+class PRReadyForReview(BaseModel):
+    """PR marked ready for review (pull_request webhook,
+    action=ready_for_review)."""
+
+    repo: str
+    pr_number: int
+
+
 class PRCommentCreated(BaseModel):
     """New comment on PR (issue_comment on PR, action=created)."""
 

--- a/coddy/observer/webhook/handlers.py
+++ b/coddy/observer/webhook/handlers.py
@@ -75,6 +75,30 @@ def _handle_pull_request_closed(
     sys.exit(0)
 
 
+def _handle_pull_request_draft(
+    config: Any,
+    payload: Dict[str, Any],
+    repo_dir: Path,
+    log: logging.Logger,
+) -> None:
+    """Handle PR draft transitions (converted_to_draft / ready_for_review)."""
+    action = payload.get("action")
+    if action not in ("converted_to_draft", "ready_for_review"):
+        return
+    pull = payload.get("pull_request") or {}
+    pr_number = pull.get("number")
+    repo_payload = payload.get("repository") or {}
+    repo_full_name = repo_payload.get("full_name") or ""
+    if repo_full_name and repo_full_name != getattr(config.bot, "repository", ""):
+        log.debug("PR #%s: skipping %s - repository %s is not configured repo", pr_number, action, repo_full_name)
+        return
+    if pr_number is None or not repo_full_name:
+        return
+    new_status = "draft" if action == "converted_to_draft" else "open"
+    set_pr_status(repo_dir, int(pr_number), new_status, repo=repo_full_name)
+    log.info("PR #%s: %s -> status %s", pr_number, action, new_status)
+
+
 def _parse_comment_timestamp(iso_str: str | None) -> int | None:
     """Parse GitHub ISO date to Unix timestamp, or None if missing/invalid."""
     if not iso_str:
@@ -314,6 +338,8 @@ def handle_github_event(
 
     Supported events:
     - pull_request (action=closed, merged=true): git pull from default branch, then exit 0 to allow restart.
+    - pull_request (action=converted_to_draft): set PR status to draft.
+    - pull_request (action=ready_for_review): set PR status back to open.
     - issues (action=assigned): if bot is in assignees, set status pending_plan (worker builds plan).
     - issue_comment: on user confirmation set issue status to queued.
     """
@@ -321,7 +347,11 @@ def handle_github_event(
     work_dir = Path(repo_dir) if repo_dir is not None else _working_dir_from_config(config)
 
     if event == "pull_request":
-        _handle_pull_request_closed(config, payload, repo_dir=work_dir, log=logger)
+        action = payload.get("action")
+        if action == "closed":
+            _handle_pull_request_closed(config, payload, repo_dir=work_dir, log=logger)
+        elif action in ("converted_to_draft", "ready_for_review"):
+            _handle_pull_request_draft(config, payload, repo_dir=work_dir, log=logger)
         return
 
     if event == "issues":

--- a/coddy/services/store/pr_store.py
+++ b/coddy/services/store/pr_store.py
@@ -1,4 +1,4 @@
-"""PR storage in .coddy/pull_requests/open/, merged/, rejected/ as YAML files.
+"""PR storage in .coddy/pull_requests/open/, merged/, rejected/, draft/ as YAML files.
 
 One file per PR: {status}/{pr_id}.yaml. Status is reflected by the folder.
 When status changes, the file is moved to the correct folder.
@@ -13,7 +13,7 @@ import yaml
 from coddy.services.store.schemas import PRFile
 
 PRS_DIR = ".coddy/pull_requests"
-PR_STATUSES = ("open", "merged", "rejected")
+PR_STATUSES = ("open", "merged", "rejected", "draft")
 
 LOG = logging.getLogger("coddy.services.store.pr_store")
 
@@ -29,10 +29,9 @@ def _pr_path(repo_dir: Path, pr_id: int, status: str = "open") -> Path:
 
 
 def load_pr(repo_dir: Path, pr_id: int) -> PRFile | None:
-    """Load PR from .coddy/pull_requests/{open|merged|rejected}/{pr_id}.yaml.
+    """Load PR from .coddy/pull_requests/{open|merged|rejected|draft}/{pr_id}.yaml.
 
-    Searches in open, merged, rejected. Returns None if missing or
-    invalid.
+    Searches all status folders. Returns None if missing or invalid.
     """
     for status in PR_STATUSES:
         path = _pr_path(repo_dir, pr_id, status)
@@ -79,7 +78,7 @@ def set_pr_status(
     repo: str | None = None,
     issue_number: int | None = None,
 ) -> None:
-    """Create or update PR file with given status (open, merged, rejected).
+    """Create or update PR file with given status (open, merged, rejected, draft).
 
     If status changes, the file is written to the new folder; the old
     file is removed if it existed in another folder. Accepts "closed" as

--- a/coddy/services/store/schemas/pr_file.py
+++ b/coddy/services/store/schemas/pr_file.py
@@ -11,7 +11,7 @@ class PRFile(BaseModel):
     repo: str = Field(..., description="Repository full_name, e.g. owner/repo")
     status: str = Field(
         default="open",
-        description="PR state: open, merged, or rejected (closed without merge). Determines folder.",
+        description="PR state: open, merged, rejected (closed without merge), or draft. Determines folder.",
     )
     issue_id: int | None = Field(default=None, description="Linked issue ID if any")
     created_at: str = Field(..., description="ISO timestamp when record was created")

--- a/tests/test_pr_draft.py
+++ b/tests/test_pr_draft.py
@@ -1,0 +1,317 @@
+"""Tests for draft PR status support (open->draft, draft->open, draft->merged, etc.)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from coddy.observer.webhook.handlers import handle_github_event
+from coddy.services.store import load_pr, save_pr, set_pr_status
+from coddy.services.store.pr_store import PR_STATUSES
+from coddy.services.store.schemas import PRFile
+
+# --- PR store: draft in PR_STATUSES ---
+
+
+def test_draft_in_pr_statuses() -> None:
+    """'draft' must be a valid PR status."""
+    assert "draft" in PR_STATUSES
+
+
+# --- PR store: set_pr_status with draft ---
+
+
+def test_set_pr_status_creates_draft_file(tmp_path: Path) -> None:
+    """set_pr_status with status='draft' creates file in draft/ folder."""
+    set_pr_status(tmp_path, 100, "draft", repo="owner/repo")
+    pr_file = tmp_path / ".coddy" / "pull_requests" / "draft" / "100.yaml"
+    assert pr_file.exists()
+    data = yaml.safe_load(pr_file.read_text(encoding="utf-8"))
+    assert data["status"] == "draft"
+
+
+def test_set_pr_status_open_to_draft(tmp_path: Path) -> None:
+    """Transition open -> draft: file moves from open/ to draft/."""
+    set_pr_status(tmp_path, 101, "open", repo="owner/repo")
+    assert (tmp_path / ".coddy" / "pull_requests" / "open" / "101.yaml").exists()
+
+    set_pr_status(tmp_path, 101, "draft", repo="owner/repo")
+    assert not (tmp_path / ".coddy" / "pull_requests" / "open" / "101.yaml").exists()
+    assert (tmp_path / ".coddy" / "pull_requests" / "draft" / "101.yaml").exists()
+
+    pr = load_pr(tmp_path, 101)
+    assert pr is not None
+    assert pr.status == "draft"
+
+
+def test_set_pr_status_draft_to_open(tmp_path: Path) -> None:
+    """Transition draft -> open: file moves from draft/ to open/."""
+    set_pr_status(tmp_path, 102, "draft", repo="owner/repo")
+    assert (tmp_path / ".coddy" / "pull_requests" / "draft" / "102.yaml").exists()
+
+    set_pr_status(tmp_path, 102, "open", repo="owner/repo")
+    assert not (tmp_path / ".coddy" / "pull_requests" / "draft" / "102.yaml").exists()
+    assert (tmp_path / ".coddy" / "pull_requests" / "open" / "102.yaml").exists()
+
+    pr = load_pr(tmp_path, 102)
+    assert pr is not None
+    assert pr.status == "open"
+
+
+def test_set_pr_status_draft_to_merged(tmp_path: Path) -> None:
+    """Transition draft -> merged: file moves from draft/ to merged/."""
+    set_pr_status(tmp_path, 103, "draft", repo="owner/repo")
+    set_pr_status(tmp_path, 103, "merged", repo="owner/repo")
+
+    assert not (tmp_path / ".coddy" / "pull_requests" / "draft" / "103.yaml").exists()
+    assert (tmp_path / ".coddy" / "pull_requests" / "merged" / "103.yaml").exists()
+
+    pr = load_pr(tmp_path, 103)
+    assert pr is not None
+    assert pr.status == "merged"
+
+
+def test_set_pr_status_draft_to_rejected(tmp_path: Path) -> None:
+    """Transition draft -> rejected: file moves from draft/ to rejected/."""
+    set_pr_status(tmp_path, 104, "draft", repo="owner/repo")
+    set_pr_status(tmp_path, 104, "rejected", repo="owner/repo")
+
+    assert not (tmp_path / ".coddy" / "pull_requests" / "draft" / "104.yaml").exists()
+    assert (tmp_path / ".coddy" / "pull_requests" / "rejected" / "104.yaml").exists()
+
+
+# --- PR store: load_pr searches draft folder ---
+
+
+def test_load_pr_finds_draft(tmp_path: Path) -> None:
+    """load_pr must find PR file in the draft/ folder."""
+    set_pr_status(tmp_path, 105, "draft", repo="owner/repo")
+    pr = load_pr(tmp_path, 105)
+    assert pr is not None
+    assert pr.status == "draft"
+    assert pr.pr_id == 105
+
+
+# --- PR store: save_pr with draft status ---
+
+
+def test_save_pr_draft_writes_to_draft_folder(tmp_path: Path) -> None:
+    """save_pr with status='draft' writes to draft/ folder."""
+    pr = PRFile(
+        pr_id=106,
+        repo="owner/repo",
+        status="draft",
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+    )
+    path = save_pr(tmp_path, pr)
+    assert "draft" in str(path)
+    assert path.exists()
+
+
+# --- PRFile schema: draft status in description ---
+
+
+def test_pr_file_accepts_draft_status() -> None:
+    """PRFile model must accept 'draft' as status without validation error."""
+    pr = PRFile(
+        pr_id=107,
+        repo="owner/repo",
+        status="draft",
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+    )
+    assert pr.status == "draft"
+
+
+# --- Webhook: converted_to_draft ---
+
+
+def _make_pr_config(tmp_path: Path) -> object:
+    """Create config for PR webhook tests."""
+    config = type("Config", (), {})()
+    config.bot = type("Bot", (), {})()
+    config.bot.git_platform = "github"
+    config.bot.repository = "owner/repo"
+    config.bot.default_branch = "main"
+    config.bot.username = "coddybot"
+    return config
+
+
+def test_webhook_pr_converted_to_draft(tmp_path: Path) -> None:
+    """On pull_request action=converted_to_draft, PR status -> draft."""
+    config = _make_pr_config(tmp_path)
+    set_pr_status(tmp_path, 200, "open", repo="owner/repo")
+
+    payload = {
+        "action": "converted_to_draft",
+        "pull_request": {"number": 200, "draft": True},
+        "repository": {"full_name": "owner/repo"},
+    }
+    handle_github_event(config, "pull_request", payload, repo_dir=tmp_path)
+
+    pr = load_pr(tmp_path, 200)
+    assert pr is not None
+    assert pr.status == "draft"
+    assert not (tmp_path / ".coddy" / "pull_requests" / "open" / "200.yaml").exists()
+    assert (tmp_path / ".coddy" / "pull_requests" / "draft" / "200.yaml").exists()
+
+
+def test_webhook_pr_ready_for_review(tmp_path: Path) -> None:
+    """On pull_request action=ready_for_review, PR status -> open."""
+    config = _make_pr_config(tmp_path)
+    set_pr_status(tmp_path, 201, "draft", repo="owner/repo")
+
+    payload = {
+        "action": "ready_for_review",
+        "pull_request": {"number": 201, "draft": False},
+        "repository": {"full_name": "owner/repo"},
+    }
+    handle_github_event(config, "pull_request", payload, repo_dir=tmp_path)
+
+    pr = load_pr(tmp_path, 201)
+    assert pr is not None
+    assert pr.status == "open"
+    assert not (tmp_path / ".coddy" / "pull_requests" / "draft" / "201.yaml").exists()
+    assert (tmp_path / ".coddy" / "pull_requests" / "open" / "201.yaml").exists()
+
+
+def test_webhook_pr_converted_to_draft_other_repo_ignored(tmp_path: Path) -> None:
+    """converted_to_draft for another repo is ignored."""
+    config = _make_pr_config(tmp_path)
+    set_pr_status(tmp_path, 202, "open", repo="owner/repo")
+
+    payload = {
+        "action": "converted_to_draft",
+        "pull_request": {"number": 202, "draft": True},
+        "repository": {"full_name": "other/repo"},
+    }
+    handle_github_event(config, "pull_request", payload, repo_dir=tmp_path)
+
+    pr = load_pr(tmp_path, 202)
+    assert pr is not None
+    assert pr.status == "open"
+
+
+# --- Webhook: closed draft PR -> merged/rejected ---
+
+
+def test_webhook_draft_pr_closed_merged(tmp_path: Path) -> None:
+    """Draft PR closed+merged moves to merged/ folder."""
+    config = _make_pr_config(tmp_path)
+    set_pr_status(tmp_path, 203, "draft", repo="owner/repo")
+
+    payload = {
+        "action": "closed",
+        "pull_request": {"number": 203, "merged": True, "draft": True},
+        "repository": {"full_name": "owner/repo"},
+    }
+    with patch("coddy.observer.webhook.handlers.run_git_pull"):
+        with patch("coddy.observer.webhook.handlers.sys.exit", side_effect=SystemExit(0)):
+            with pytest.raises(SystemExit):
+                handle_github_event(config, "pull_request", payload, repo_dir=tmp_path)
+
+    pr = load_pr(tmp_path, 203)
+    assert pr is not None
+    assert pr.status == "merged"
+
+
+def test_webhook_draft_pr_closed_rejected(tmp_path: Path) -> None:
+    """Draft PR closed without merge moves to rejected/ folder."""
+    config = _make_pr_config(tmp_path)
+    set_pr_status(tmp_path, 204, "draft", repo="owner/repo")
+
+    payload = {
+        "action": "closed",
+        "pull_request": {"number": 204, "merged": False, "draft": True},
+        "repository": {"full_name": "owner/repo"},
+    }
+    handle_github_event(config, "pull_request", payload, repo_dir=tmp_path)
+
+    pr = load_pr(tmp_path, 204)
+    assert pr is not None
+    assert pr.status == "rejected"
+
+
+# --- Sync: draft PRs detected ---
+
+
+def test_sync_detects_draft_pr(tmp_path: Path) -> None:
+    """run_sync maps open+draft PR to 'draft' status."""
+    from coddy.observer.models import PR
+    from coddy.observer.sync import run_sync
+
+    config = MagicMock()
+    config.bot.repository = "owner/repo"
+    config.bot.git_platform = "github"
+    config.github_token_resolved = "token"
+    config.github.api_url = "https://api.github.com"
+
+    draft_pr = PR(
+        number=300,
+        title="Draft PR",
+        body="WIP",
+        head_branch="feature",
+        base_branch="main",
+        state="open",
+        draft=True,
+        merged_at=None,
+    )
+    non_draft_pr = PR(
+        number=301,
+        title="Ready PR",
+        body="Done",
+        head_branch="fix",
+        base_branch="main",
+        state="open",
+        draft=False,
+        merged_at=None,
+    )
+
+    mock_adapter = MagicMock()
+    mock_adapter.list_issues.return_value = []
+    mock_adapter.list_pulls.return_value = [draft_pr, non_draft_pr]
+
+    with patch("coddy.observer.adapters.github.GitHubAdapter", return_value=mock_adapter):
+        run_sync(config, tmp_path)
+
+    assert (tmp_path / ".coddy" / "pull_requests" / "draft" / "300.yaml").exists()
+    assert (tmp_path / ".coddy" / "pull_requests" / "open" / "301.yaml").exists()
+
+    pr_draft = load_pr(tmp_path, 300)
+    assert pr_draft is not None
+    assert pr_draft.status == "draft"
+
+    pr_open = load_pr(tmp_path, 301)
+    assert pr_open is not None
+    assert pr_open.status == "open"
+
+
+# --- PR model: draft field ---
+
+
+def test_pr_model_has_draft_field() -> None:
+    """PR observer model must have a 'draft' boolean field."""
+    from coddy.observer.models import PR
+
+    pr = PR(
+        number=400,
+        title="Test",
+        body="",
+        head_branch="feature",
+        base_branch="main",
+        state="open",
+        draft=True,
+    )
+    assert pr.draft is True
+
+    pr2 = PR(
+        number=401,
+        title="Test 2",
+        body="",
+        head_branch="feature",
+        base_branch="main",
+        state="open",
+    )
+    assert pr2.draft is False


### PR DESCRIPTION
## Draft folder for draft PRs

### What was done

Added full support for "draft" PR status throughout the codebase. When a PR is converted to draft on GitHub, it is now stored in `.coddy/pull_requests/draft/` folder with `status: draft` in its YAML file. All status transitions (open->draft, draft->open, draft->merged, draft->rejected) correctly move the YAML file between folders.

**Changes by component:**

- **PR store** (`coddy/services/store/pr_store.py`) - added `"draft"` to `PR_STATUSES` tuple, `load_pr` searches the `draft/` folder, `save_pr` writes to `draft/` when status is draft, `set_pr_status` supports draft transitions and moves files between folders
- **PR schema** (`coddy/services/store/schemas/pr_file.py`) - updated status field description to include "draft"
- **PR model** (`coddy/observer/models/pr.py`) - added `draft: bool` field (default `False`) to the observer PR model
- **GitHub adapter** (`coddy/observer/adapters/github.py`) - parses `draft` field from GitHub API response when building PR model
- **Webhook handlers** (`coddy/observer/webhook/handlers.py`) - handles `converted_to_draft` and `ready_for_review` actions on `pull_request` events, setting PR status to `draft` or `open` respectively
- **Webhook events** (`coddy/observer/webhook/events/pull_request.py`) - added `PRConvertedToDraft` and `PRReadyForReview` event schemas
- **Sync** (`coddy/observer/sync.py`) - `_pr_status_from_api` maps open PRs with `draft=True` to `"draft"` status during startup sync

### How to test

Run the full test suite:

```bash
pytest tests/ -v
```

Or run just the draft PR tests:

```bash
pytest tests/test_pr_draft.py -v
```

16 new tests cover:
- `"draft"` presence in `PR_STATUSES`
- `set_pr_status` creating a file in `draft/` folder
- All status transitions: open->draft, draft->open, draft->merged, draft->rejected
- `load_pr` finding files in `draft/` folder
- `save_pr` writing to `draft/` folder
- `PRFile` schema accepting `"draft"` status
- Webhook handling for `converted_to_draft` and `ready_for_review` events
- Webhook ignoring events from other repositories
- Draft PR closed+merged and closed+rejected transitions via webhook
- Sync correctly detecting and mapping draft PRs from API
- `PR` observer model having the `draft` boolean field

### Tests and linter results

- All 193 tests passed
- Ruff linter: all checks passed on changed files
- pre-commit: docformatter hook has a pre-existing Python 3.14 compatibility issue (not related to this change)

Closes #23