### PR TITLE
Добавь возможнность проводить ревью PR

### DIFF
--- a/coddy/observer/adapters/base.py
+++ b/coddy/observer/adapters/base.py
@@ -118,3 +118,22 @@ class GitPlatformAdapter(ABC):
         Override if needed.
         """
         raise NotImplementedError("reply_to_review_comment")
+
+    def create_pr_comment(self, repo: str, pr_number: int, body: str) -> Comment:
+        """Post a general comment on a PR (issue-style comment, not line-level).
+
+        Override if needed.
+        """
+        return self.create_comment(repo, pr_number, body)
+
+    def get_pr_comments(
+        self,
+        repo: str,
+        pr_number: int,
+        since: datetime | None = None,
+    ) -> List[Comment]:
+        """Fetch general comments on a PR.
+
+        Override if needed.
+        """
+        return self.get_issue_comments(repo, pr_number, since)

--- a/coddy/observer/clarification_poll.py
+++ b/coddy/observer/clarification_poll.py
@@ -3,9 +3,11 @@
 - plan_ready: worker wrote the plan; post last comment to GitHub, set waiting_confirmation.
 - waiting_user_reply: post last comment (clarification), set clarification_sent.
 - pull_requests/pending/: worker wrote PR request; create PR via API, move to open/, set label review.
+- review_received: idle timeout passed since last review; set pending_plan for worker to process.
 """
 
 import logging
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -15,9 +17,11 @@ from coddy.services.store import (
     delete_pending_pr_request,
     list_issues_by_status,
     list_pending_pr_requests,
+    list_prs_by_workflow_status,
     mark_clarification_sent,
     save_pr,
     set_issue_status,
+    set_pr_workflow_status,
 )
 from coddy.services.store.schemas import PRFile
 
@@ -178,3 +182,36 @@ def run_create_pr_poll(
             logger.info("Created PR #%s for issue #%s, label set to review", pr_number, issue_id)
         except GitPlatformError as e:
             logger.warning("Failed to create PR for issue #%s: %s", issue_id, e)
+
+
+DEFAULT_REVIEW_IDLE_TIMEOUT = 30
+
+
+def run_review_idle_poll(
+    config: Any,
+    repo_dir: Path,
+    log: logging.Logger | None = None,
+    idle_timeout: int | None = None,
+) -> None:
+    """Check PRs with workflow_status=review_received.
+
+    If idle timeout has passed since last_review_ts, transition to
+    pending_plan so the worker can generate a review response plan.
+    """
+    logger = log or LOG
+    received = list_prs_by_workflow_status(repo_dir, "review_received")
+    if not received:
+        return
+
+    timeout = idle_timeout if idle_timeout is not None else DEFAULT_REVIEW_IDLE_TIMEOUT
+    now = int(time.time())
+
+    for pr_id, pr_file in received:
+        last_ts = pr_file.last_review_ts or 0
+        if now - last_ts >= timeout:
+            set_pr_workflow_status(repo_dir, pr_id, "pending_plan")
+            logger.info(
+                "PR #%s: idle timeout reached (%ss since last review), workflow_status -> pending_plan",
+                pr_id,
+                now - last_ts,
+            )

--- a/coddy/observer/run.py
+++ b/coddy/observer/run.py
@@ -21,6 +21,7 @@ from coddy.observer.clarification_poll import (
     run_clarification_poll,
     run_create_pr_poll,
     run_plan_post_poll,
+    run_review_idle_poll,
 )
 from coddy.observer.sync import run_sync
 from coddy.observer.webhook.handlers import _working_dir_from_config
@@ -57,6 +58,7 @@ def _clarification_poll_loop(config: AppConfig, work_dir: Path, log: logging.Log
             run_plan_post_poll(config, work_dir, log=log)
             run_clarification_poll(config, work_dir, log=log)
             run_create_pr_poll(config, work_dir, log=log)
+            run_review_idle_poll(config, work_dir, log=log)
         except Exception as e:
             log.warning("Poll error: %s", e)
 

--- a/coddy/observer/webhook/handlers.py
+++ b/coddy/observer/webhook/handlers.py
@@ -16,9 +16,12 @@ from coddy.observer.planner import is_affirmative_comment, on_user_confirmed
 from coddy.services.git import GitRunnerError, run_git_pull
 from coddy.services.store import (
     add_comment,
+    add_review,
+    add_review_comment,
     create_issue,
     delete_comment,
     load_issue,
+    load_pr,
     save_issue,
     set_issue_state,
     set_issue_status,
@@ -324,6 +327,155 @@ def _handle_issues_assigned(
     log.info("Issue #%s assigned, status -> pending_plan (worker will build plan)", issue_number)
 
 
+def _handle_pull_request_review(
+    config: Any,
+    payload: Dict[str, Any],
+    repo_dir: Path,
+    log: logging.Logger,
+) -> None:
+    """On pull_request_review submitted: store review in PR file."""
+    action = payload.get("action")
+    if action != "submitted":
+        return
+    review_payload = payload.get("review") or {}
+    pr_payload = payload.get("pull_request") or {}
+    pr_number = pr_payload.get("number")
+    repo_payload = payload.get("repository") or {}
+    repo = repo_payload.get("full_name") or getattr(config.bot, "repository", "")
+    if not repo or repo != getattr(config.bot, "repository", ""):
+        return
+    if pr_number is None:
+        return
+
+    bot_username = getattr(config.bot, "username", None)
+    user = review_payload.get("user") or {}
+    author = user.get("login", "")
+    if bot_username and author == bot_username:
+        return
+
+    review_id = review_payload.get("id")
+    state = review_payload.get("state", "commented")
+    body = review_payload.get("body") or ""
+    ts = _parse_comment_timestamp(review_payload.get("submitted_at")) or int(datetime.now(UTC).timestamp())
+
+    pr = load_pr(repo_dir, int(pr_number))
+    if not pr:
+        set_pr_status(repo_dir, int(pr_number), "open", repo=repo)
+
+    add_review(
+        repo_dir,
+        int(pr_number),
+        review_id=int(review_id) if review_id is not None else 0,
+        author=author,
+        state=state,
+        body=body,
+        created_at=ts,
+    )
+    log.info("PR #%s: review %s submitted by %s (state=%s)", pr_number, review_id, author, state)
+
+
+def _handle_pull_request_review_comment(
+    config: Any,
+    payload: Dict[str, Any],
+    repo_dir: Path,
+    log: logging.Logger,
+) -> None:
+    """On pull_request_review_comment created/edited: store comment in PR file."""
+    action = payload.get("action")
+    if action not in ("created", "edited"):
+        return
+    comment_payload = payload.get("comment") or {}
+    pr_payload = payload.get("pull_request") or {}
+    pr_number = pr_payload.get("number")
+    repo_payload = payload.get("repository") or {}
+    repo = repo_payload.get("full_name") or getattr(config.bot, "repository", "")
+    if not repo or repo != getattr(config.bot, "repository", ""):
+        return
+    if pr_number is None:
+        return
+
+    bot_username = getattr(config.bot, "username", None)
+    user = comment_payload.get("user") or {}
+    author = user.get("login", "")
+    if bot_username and author == bot_username:
+        return
+
+    comment_id = comment_payload.get("id")
+    if comment_id is None:
+        return
+
+    review_id = comment_payload.get("pull_request_review_id")
+    content = comment_payload.get("body") or ""
+    path = comment_payload.get("path") or ""
+    line = comment_payload.get("line")
+    in_reply_to_id = comment_payload.get("in_reply_to_id")
+    ts = _parse_comment_timestamp(comment_payload.get("created_at")) or int(datetime.now(UTC).timestamp())
+
+    pr = load_pr(repo_dir, int(pr_number))
+    if not pr:
+        set_pr_status(repo_dir, int(pr_number), "open", repo=repo)
+
+    add_review_comment(
+        repo_dir,
+        int(pr_number),
+        review_id=int(review_id) if review_id is not None else None,
+        comment_id=int(comment_id),
+        author=author,
+        content=content,
+        path=path,
+        line=line,
+        created_at=ts,
+        in_reply_to_id=int(in_reply_to_id) if in_reply_to_id is not None else None,
+    )
+    log.info("PR #%s: review comment %s on %s:%s by %s", pr_number, comment_id, path, line, author)
+
+
+def _handle_pr_issue_comment(
+    config: Any,
+    payload: Dict[str, Any],
+    repo_dir: Path,
+    log: logging.Logger,
+) -> None:
+    """Handle issue_comment on a PR (general PR comment, not line-level).
+
+    If PR has workflow_status=waiting_confirmation and comment is affirmative,
+    set workflow_status to in_progress.
+    """
+    action = payload.get("action")
+    if action != "created":
+        return
+    comment_payload = payload.get("comment") or {}
+    body = comment_payload.get("body") or ""
+    user = comment_payload.get("user") or {}
+    author = user.get("login", "")
+    bot_username = getattr(config.bot, "username", None)
+    if bot_username and author == bot_username:
+        return
+
+    issue_payload = payload.get("issue") or {}
+    pr_number = issue_payload.get("number")
+    if pr_number is None:
+        return
+
+    if not issue_payload.get("pull_request"):
+        return
+
+    repo_payload = payload.get("repository") or {}
+    repo = repo_payload.get("full_name") or getattr(config.bot, "repository", "")
+    if not repo or repo != getattr(config.bot, "repository", ""):
+        return
+
+    pr = load_pr(repo_dir, int(pr_number))
+    if not pr:
+        return
+
+    if pr.workflow_status == "waiting_confirmation" and is_affirmative_comment(body):
+        from coddy.services.store import set_pr_workflow_status
+
+        set_pr_workflow_status(repo_dir, int(pr_number), "in_progress")
+        log.info("PR #%s: user confirmed review plan, workflow_status -> in_progress", pr_number)
+
+
 def handle_github_event(
     config: Any,
     event: str,
@@ -337,8 +489,10 @@ def handle_github_event(
     - pull_request (action=closed, merged=true): git pull from default branch, then exit 0 to allow restart.
     - pull_request (action=converted_to_draft): set PR status to draft.
     - pull_request (action=ready_for_review): set PR status to open.
+    - pull_request_review (action=submitted): store review in PR file.
+    - pull_request_review_comment (action=created/edited): store line comment in PR file.
     - issues (action=assigned): if bot is in assignees, set status pending_plan (worker builds plan).
-    - issue_comment: on user confirmation set issue status to queued.
+    - issue_comment: on user confirmation set issue status to queued; on PR comment check review confirmation.
     """
     logger = log or logging.getLogger("coddy.observer.webhook.handlers")
     work_dir = Path(repo_dir) if repo_dir is not None else _working_dir_from_config(config)
@@ -353,10 +507,19 @@ def handle_github_event(
             _handle_pull_request_draft_or_ready(config, payload, "open", repo_dir=work_dir, log=logger)
         return
 
+    if event == "pull_request_review":
+        _handle_pull_request_review(config, payload, work_dir, logger)
+        return
+
+    if event == "pull_request_review_comment":
+        _handle_pull_request_review_comment(config, payload, work_dir, logger)
+        return
+
     if event == "issues":
         _handle_issues(config, payload, work_dir, logger)
         return
 
     if event == "issue_comment":
+        _handle_pr_issue_comment(config, payload, work_dir, logger)
         _handle_issue_comment(config, payload, work_dir, logger)
         return

--- a/coddy/services/store/__init__.py
+++ b/coddy/services/store/__init__.py
@@ -17,27 +17,36 @@ from coddy.services.store.issue_store import (
     update_comment,
 )
 from coddy.services.store.pr_store import (
+    add_review,
+    add_review_comment,
     delete_pending_pr_request,
     list_pending_pr_requests,
+    list_prs_by_workflow_status,
     load_pr,
     save_pending_pr_request,
     save_pr,
     set_pr_status,
+    set_pr_workflow_status,
 )
-from coddy.services.store.schemas import IssueComment, IssueFile, PendingPRRequest, PRFile
+from coddy.services.store.schemas import IssueComment, IssueFile, PendingPRRequest, PRFile, PRReview, PRReviewComment
 
 __all__ = [
     "IssueComment",
     "IssueFile",
     "PendingPRRequest",
     "PRFile",
+    "PRReview",
+    "PRReviewComment",
     "add_comment",
+    "add_review",
+    "add_review_comment",
     "delete_pending_pr_request",
     "create_issue",
     "delete_comment",
     "list_issues_by_status",
     "list_pending_plan",
     "list_pending_pr_requests",
+    "list_prs_by_workflow_status",
     "list_queued",
     "load_issue",
     "load_pr",
@@ -49,5 +58,6 @@ __all__ = [
     "set_issue_state",
     "set_issue_status",
     "set_pr_status",
+    "set_pr_workflow_status",
     "update_comment",
 ]

--- a/coddy/services/store/pr_store.py
+++ b/coddy/services/store/pr_store.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import yaml
 
-from coddy.services.store.schemas import PendingPRRequest, PRFile
+from coddy.services.store.schemas import PendingPRRequest, PRFile, PRReview, PRReviewComment
 
 PRS_DIR = ".coddy/pull_requests"
 PR_STATUSES = ("open", "merged", "rejected", "draft")
@@ -178,3 +178,148 @@ def delete_pending_pr_request(repo_dir: Path, issue_id: int) -> None:
     if path.is_file():
         path.unlink()
         LOG.debug("Deleted pending PR request for issue #%s", issue_id)
+
+
+def add_review(
+    repo_dir: Path,
+    pr_id: int,
+    review_id: int,
+    author: str,
+    state: str,
+    body: str,
+    created_at: int,
+) -> None:
+    """Add or update a review entry in the PR file.
+
+    If review with the same review_id already exists, update it.
+    Sets workflow_status to review_received and updates last_review_ts.
+    """
+    pr = load_pr(repo_dir, pr_id)
+    if not pr:
+        LOG.warning("Cannot add review: PR #%s not found", pr_id)
+        return
+
+    existing = {r.review_id: r for r in pr.reviews}
+    if review_id in existing:
+        rev = existing[review_id]
+        rev.state = state
+        rev.body = body
+    else:
+        rev = PRReview(
+            review_id=review_id,
+            author=author,
+            state=state,
+            body=body,
+            created_at=created_at,
+        )
+        pr.reviews.append(rev)
+
+    pr.last_review_ts = created_at
+    pr.workflow_status = "review_received"
+    pr.updated_at = datetime.now(UTC).isoformat()
+    save_pr(repo_dir, pr)
+    LOG.info("PR #%s: added review %s by %s (state=%s)", pr_id, review_id, author, state)
+
+
+def add_review_comment(
+    repo_dir: Path,
+    pr_id: int,
+    review_id: int | None,
+    comment_id: int,
+    author: str,
+    content: str,
+    path: str,
+    line: int | None,
+    created_at: int,
+    in_reply_to_id: int | None = None,
+) -> None:
+    """Add a line-level review comment to the PR file.
+
+    If review_id is given and a matching review exists, the comment is
+    appended to that review; otherwise a new ad-hoc review is created.
+    Sets workflow_status to review_received and updates last_review_ts.
+    """
+    pr = load_pr(repo_dir, pr_id)
+    if not pr:
+        LOG.warning("Cannot add review comment: PR #%s not found", pr_id)
+        return
+
+    comment = PRReviewComment(
+        comment_id=comment_id,
+        name=author,
+        content=content,
+        path=path,
+        line=line,
+        created_at=created_at,
+        updated_at=created_at,
+        in_reply_to_id=in_reply_to_id,
+    )
+
+    target_review: PRReview | None = None
+    if review_id is not None:
+        for rev in pr.reviews:
+            if rev.review_id == review_id:
+                target_review = rev
+                break
+
+    if target_review is None:
+        target_review = PRReview(
+            review_id=review_id,
+            author=author,
+            state="commented",
+            body="",
+            created_at=created_at,
+        )
+        pr.reviews.append(target_review)
+
+    for existing in target_review.comments:
+        if existing.comment_id == comment_id:
+            existing.content = content
+            existing.updated_at = created_at
+            existing.path = path
+            existing.line = line
+            break
+    else:
+        target_review.comments.append(comment)
+
+    pr.last_review_ts = created_at
+    pr.workflow_status = "review_received"
+    pr.updated_at = datetime.now(UTC).isoformat()
+    save_pr(repo_dir, pr)
+    LOG.info("PR #%s: added review comment %s on %s:%s", pr_id, comment_id, path, line)
+
+
+def set_pr_workflow_status(repo_dir: Path, pr_id: int, workflow_status: str) -> None:
+    """Update PR workflow_status field."""
+    pr = load_pr(repo_dir, pr_id)
+    if not pr:
+        LOG.warning("Cannot set workflow_status: PR #%s not found", pr_id)
+        return
+    pr.workflow_status = workflow_status
+    pr.updated_at = datetime.now(UTC).isoformat()
+    save_pr(repo_dir, pr)
+    LOG.info("PR #%s workflow_status -> %s", pr_id, workflow_status)
+
+
+def list_prs_by_workflow_status(repo_dir: Path, workflow_status: str) -> list[tuple[int, PRFile]]:
+    """List all PRs with the given workflow_status.
+
+    Scans all status folders. Returns list of (pr_id, PRFile).
+    """
+    base = _prs_dir(repo_dir)
+    out: list[tuple[int, PRFile]] = []
+    for status in PR_STATUSES:
+        subdir = base / status
+        if not subdir.is_dir():
+            continue
+        for f in sorted(subdir.glob("*.yaml")):
+            if not f.stem.isdigit():
+                continue
+            try:
+                pr_id = int(f.stem)
+                pr = load_pr(repo_dir, pr_id)
+                if pr and pr.workflow_status == workflow_status:
+                    out.append((pr_id, pr))
+            except (ValueError, Exception):
+                continue
+    return out

--- a/coddy/services/store/schemas/__init__.py
+++ b/coddy/services/store/schemas/__init__.py
@@ -2,6 +2,15 @@
 
 from coddy.services.store.schemas.issue_comment import IssueComment
 from coddy.services.store.schemas.issue_file import IssueFile
-from coddy.services.store.schemas.pr_file import PendingPRRequest, PRFile
+from coddy.services.store.schemas.pr_file import PR_WORKFLOW_STATUSES, PendingPRRequest, PRFile
+from coddy.services.store.schemas.pr_review import PRReview, PRReviewComment
 
-__all__ = ["IssueComment", "IssueFile", "PendingPRRequest", "PRFile"]
+__all__ = [
+    "IssueComment",
+    "IssueFile",
+    "PR_WORKFLOW_STATUSES",
+    "PendingPRRequest",
+    "PRFile",
+    "PRReview",
+    "PRReviewComment",
+]

--- a/coddy/services/store/schemas/pr_file.py
+++ b/coddy/services/store/schemas/pr_file.py
@@ -4,7 +4,11 @@ Pending request: .coddy/pull_requests/pending/{issue_id}.yaml (worker writes,
 observer creates PR and moves to open/{pr_id}.yaml).
 """
 
+from typing import List
+
 from pydantic import BaseModel, Field
+
+from coddy.services.store.schemas.pr_review import PRReview
 
 
 class PendingPRRequest(BaseModel):
@@ -24,6 +28,15 @@ class PendingPRRequest(BaseModel):
     model_config = {"extra": "forbid", "populate_by_name": True}
 
 
+PR_WORKFLOW_STATUSES = (
+    "idle",
+    "review_received",
+    "pending_plan",
+    "waiting_confirmation",
+    "in_progress",
+)
+
+
 class PRFile(BaseModel):
     """PR record as stored in
     .coddy/pull_requests/{status}/{pr_number}.yaml."""
@@ -34,11 +47,20 @@ class PRFile(BaseModel):
         default="open",
         description="PR state: open, draft, merged, or rejected (closed without merge). Determines folder.",
     )
+    workflow_status: str = Field(
+        default="idle",
+        description="Review workflow: idle, review_received, pending_plan, waiting_confirmation, in_progress",
+    )
     issue_id: int | None = Field(default=None, description="Linked issue ID if any")
+    reviews: List[PRReview] = Field(default_factory=list, description="Submitted reviews with line-level comments")
+    last_review_ts: int | None = Field(
+        default=None,
+        description="Unix timestamp of last review/comment received (for idle timeout)",
+    )
     created_at: str = Field(..., description="ISO timestamp when record was created")
     updated_at: str = Field(..., description="ISO timestamp of last status update")
 
-    model_config = {"extra": "forbid", "populate_by_name": True}
+    model_config = {"extra": "ignore", "populate_by_name": True}
 
     def to_markdown(self) -> str:
         """Render PR record as markdown."""

--- a/coddy/services/store/schemas/pr_review.py
+++ b/coddy/services/store/schemas/pr_review.py
@@ -1,0 +1,29 @@
+"""PR review and review comment schemas for .coddy/pull_requests/."""
+
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class PRReviewComment(BaseModel):
+    """Single comment within a PR review (line-level or file-level)."""
+
+    comment_id: int | None = Field(default=None, description="Platform comment id")
+    name: str = Field(..., description="Author login, e.g. @username")
+    content: str = Field(..., description="Comment body")
+    path: str = Field(default="", description="File path relative to repo root")
+    line: int | None = Field(default=None, description="Line number in the file")
+    created_at: int = Field(..., description="Unix timestamp when comment was created")
+    updated_at: int = Field(..., description="Unix timestamp when comment was last updated")
+    in_reply_to_id: int | None = Field(default=None, description="Parent comment id (for threaded replies)")
+
+
+class PRReview(BaseModel):
+    """A single review submitted on a PR."""
+
+    review_id: int | None = Field(default=None, description="Platform review id")
+    author: str = Field(..., description="Reviewer login")
+    state: str = Field(default="commented", description="Review state: approved, changes_requested, commented")
+    body: str = Field(default="", description="Top-level review body")
+    comments: List[PRReviewComment] = Field(default_factory=list, description="Line-level review comments")
+    created_at: int = Field(..., description="Unix timestamp when review was submitted")

--- a/coddy/worker/review_loop.py
+++ b/coddy/worker/review_loop.py
@@ -1,0 +1,135 @@
+"""Review loop: process PR review comments using the AI agent.
+
+For each unresolved review comment, the agent either applies a code fix
+or writes a reply. Replies are posted back to the PR comment thread.
+"""
+
+import logging
+from pathlib import Path
+from typing import Literal
+
+from coddy.observer.adapters.base import GitPlatformAdapter, GitPlatformError
+from coddy.observer.models import ReviewComment
+from coddy.services.git import (
+    checkout_branch,
+    commit_all_and_push,
+    fetch_and_checkout_branch,
+    set_commit_author,
+)
+from coddy.services.store.schemas import PRFile
+from coddy.worker.agents.base import AIAgent
+from coddy.worker.task_yaml import read_review_reply
+
+ResultKind = Literal["success", "failed"]
+
+LOG = logging.getLogger("coddy.worker.review_loop")
+
+
+def run_review_loop_for_pr(
+    adapter: GitPlatformAdapter,
+    agent: AIAgent,
+    pr_file: PRFile,
+    repo: str,
+    repo_dir: Path,
+    *,
+    bot_username: str | None = None,
+    bot_name: str | None = None,
+    bot_email: str | None = None,
+    default_branch: str | None = None,
+    log: logging.Logger | None = None,
+) -> ResultKind:
+    """Process all review comments on a PR.
+
+    Checks out the PR branch, runs agent for each comment, commits
+    changes, posts replies.
+    """
+    logger = log or LOG
+    pr_number = pr_file.pr_id
+    issue_number = pr_file.issue_id or 0
+
+    review_comments: list[ReviewComment] = []
+    for review in pr_file.reviews:
+        for comment in review.comments:
+            if comment.in_reply_to_id is not None:
+                continue
+            review_comments.append(
+                ReviewComment(
+                    id=comment.comment_id or 0,
+                    body=comment.content,
+                    author=comment.name,
+                    path=comment.path,
+                    line=comment.line,
+                    side="RIGHT",
+                    created_at=comment.created_at,
+                    updated_at=comment.updated_at,
+                )
+            )
+
+    if not review_comments:
+        logger.info("PR #%s: no review comments to process", pr_number)
+        return "success"
+
+    try:
+        pr = adapter.get_pr(repo, pr_number)
+        head_branch = pr.head_branch
+    except Exception as e:
+        logger.warning("PR #%s: failed to get PR from platform: %s", pr_number, e)
+        return "failed"
+
+    try:
+        fetch_and_checkout_branch(head_branch, repo_dir=repo_dir, log=logger)
+    except Exception as e:
+        logger.warning("PR #%s: failed to checkout branch %s: %s", pr_number, head_branch, e)
+        return "failed"
+
+    if bot_name and bot_email:
+        set_commit_author(bot_name, bot_email, repo_dir=repo_dir, log=logger)
+
+    for idx, comment in enumerate(review_comments, 1):
+        logger.info(
+            "PR #%s: processing review comment %d/%d on %s:%s",
+            pr_number,
+            idx,
+            len(review_comments),
+            comment.path,
+            comment.line,
+        )
+        try:
+            reply = agent.process_review_item(
+                pr_number=pr_number,
+                issue_number=issue_number,
+                comments=review_comments,
+                current_index=idx,
+                repo_dir=repo_dir,
+            )
+        except Exception as e:
+            logger.warning("PR #%s: agent failed for comment %d: %s", pr_number, idx, e)
+            reply = None
+
+        if reply is None:
+            reply = read_review_reply(repo_dir, pr_number, comment.id)
+
+        if reply and comment.id:
+            try:
+                adapter.reply_to_review_comment(repo, pr_number, comment.id, reply)
+                logger.info("PR #%s: replied to comment %s", pr_number, comment.id)
+            except GitPlatformError as e:
+                logger.warning("PR #%s: failed to reply to comment %s: %s", pr_number, comment.id, e)
+
+    try:
+        commit_all_and_push(
+            f"#{issue_number} Address review comments on PR #{pr_number}",
+            repo_dir=repo_dir,
+            log=logger,
+        )
+    except Exception as e:
+        logger.warning("PR #%s: commit/push failed (no changes?): %s", pr_number, e)
+
+    if default_branch:
+        try:
+            checkout_branch(default_branch, repo_dir=repo_dir, log=logger)
+        except Exception:
+            pass
+
+    logger.info("PR #%s: review loop complete", pr_number)
+    return "success"

--- a/coddy/worker/run.py
+++ b/coddy/worker/run.py
@@ -20,14 +20,18 @@ from coddy.logging import CoddyLogging
 from coddy.observer.models import Comment, Issue
 from coddy.services.store import (
     IssueFile,
+    PRFile,
     add_comment,
     list_issues_by_status,
     list_pending_plan,
+    list_prs_by_workflow_status,
     list_queued,
     set_agent_clarification,
     set_issue_status,
+    set_pr_workflow_status,
 )
 from coddy.worker.ralph_loop import run_ralph_loop_for_issue
+from coddy.worker.review_loop import run_review_loop_for_pr
 from coddy.worker.task_yaml import report_file_path
 
 
@@ -209,7 +213,111 @@ def run_worker_poll(
             log.info("Dry run: wrote empty PR YAML for issue #%s", issue_number)
         did_work = True
 
+    if not did_work:
+        did_work = _process_pr_reviews(config, repo_dir, adapter, agent, log)
+
     return did_work
+
+
+def _process_pr_reviews(
+    config: AppConfig,
+    repo_dir: Path,
+    adapter: Any,
+    agent: Any,
+    log: logging.Logger,
+) -> bool:
+    """Process PRs with workflow_status=pending_plan or in_progress.
+
+    pending_plan: generate review response plan, post as PR comment, set waiting_confirmation.
+    in_progress: run review loop (apply fixes via agent), set idle.
+    """
+    repo = config.bot.repository
+    bot_username = getattr(config.bot, "username", None)
+    did_work = False
+
+    pending = list_prs_by_workflow_status(repo_dir, "pending_plan")
+    for pr_id, pr_file in pending:
+        if not adapter or not agent:
+            break
+        try:
+            review_comments = _collect_review_comments(pr_file)
+            if not review_comments:
+                set_pr_workflow_status(repo_dir, pr_id, "idle")
+                continue
+            plan = _build_review_plan(review_comments)
+            confirmation_msg = (
+                f"## Review response plan\n\n{plan}\n\n---\n\n"
+                "Does this look good? Reply with **yes** / **go ahead** to start applying fixes."
+            )
+            try:
+                adapter.create_pr_comment(repo, pr_id, confirmation_msg)
+            except Exception as e:
+                log.warning("PR #%s: failed to post review plan: %s", pr_id, e)
+            set_pr_workflow_status(repo_dir, pr_id, "waiting_confirmation")
+            log.info("PR #%s: posted review response plan, workflow_status -> waiting_confirmation", pr_id)
+            did_work = True
+        except Exception as e:
+            log.warning("PR #%s: review plan failed: %s", pr_id, e)
+
+    in_progress = list_prs_by_workflow_status(repo_dir, "in_progress")
+    for pr_id, pr_file in in_progress:
+        if not adapter or not agent:
+            break
+        try:
+            result = run_review_loop_for_pr(
+                adapter=adapter,
+                agent=agent,
+                pr_file=pr_file,
+                repo=repo,
+                repo_dir=repo_dir,
+                bot_username=bot_username,
+                bot_name=getattr(config.bot, "name", None),
+                bot_email=getattr(config.bot, "email", None),
+                default_branch=getattr(config.bot, "default_branch", "main"),
+                log=log,
+            )
+            if result == "success":
+                set_pr_workflow_status(repo_dir, pr_id, "idle")
+                log.info("PR #%s: review fixes applied, workflow_status -> idle", pr_id)
+            else:
+                set_pr_workflow_status(repo_dir, pr_id, "idle")
+                log.warning("PR #%s: review loop result=%s, workflow_status -> idle", pr_id, result)
+            did_work = True
+        except Exception as e:
+            log.exception("PR #%s: review loop failed: %s", pr_id, e)
+            set_pr_workflow_status(repo_dir, pr_id, "idle")
+
+    return did_work
+
+
+def _collect_review_comments(pr_file: PRFile) -> list[dict[str, Any]]:
+    """Extract all review comments with file/line info from a PR file."""
+    items: list[dict[str, Any]] = []
+    for review in pr_file.reviews:
+        for comment in review.comments:
+            if comment.in_reply_to_id is not None:
+                continue
+            items.append(
+                {
+                    "comment_id": comment.comment_id,
+                    "author": comment.name,
+                    "body": comment.content,
+                    "path": comment.path,
+                    "line": comment.line,
+                    "review_id": review.review_id,
+                }
+            )
+    return items
+
+
+def _build_review_plan(review_comments: list[dict[str, Any]]) -> str:
+    """Build a markdown plan summarizing review comments to address."""
+    lines = []
+    for i, item in enumerate(review_comments, 1):
+        line_display = str(item["line"]) if item.get("line") is not None else "file-level"
+        body_preview = item["body"][:80] + ("..." if len(item["body"]) > 80 else "")
+        lines.append(f"{i}. `{item['path']}` line {line_display} (@{item['author']}): {body_preview}")
+    return "\n".join(lines)
 
 
 def run_worker(config: AppConfig, once: bool = False, poll_interval: int = 15) -> None:

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -1,0 +1,1114 @@
+"""Tests for PR review feature: schemas, store functions, webhook handlers,
+idle timeout, worker processing, and review loop."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from coddy.observer.clarification_poll import run_review_idle_poll
+from coddy.observer.webhook.handlers import handle_github_event
+from coddy.services.store import (
+    add_review,
+    add_review_comment,
+    list_prs_by_workflow_status,
+    load_pr,
+    save_pr,
+    set_pr_status,
+    set_pr_workflow_status,
+)
+from coddy.services.store.schemas import PRFile, PRReview, PRReviewComment
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestPRReviewSchemas:
+    """Tests for PRReview and PRReviewComment pydantic models."""
+
+    def test_pr_review_comment_all_fields(self) -> None:
+        c = PRReviewComment(
+            comment_id=100,
+            name="reviewer",
+            content="Fix this line",
+            path="src/main.py",
+            line=42,
+            created_at=1000,
+            updated_at=1000,
+            in_reply_to_id=None,
+        )
+        assert c.comment_id == 100
+        assert c.name == "reviewer"
+        assert c.content == "Fix this line"
+        assert c.path == "src/main.py"
+        assert c.line == 42
+        assert c.in_reply_to_id is None
+
+    def test_pr_review_comment_minimal(self) -> None:
+        c = PRReviewComment(name="u", content="ok", created_at=0, updated_at=0)
+        assert c.comment_id is None
+        assert c.path == ""
+        assert c.line is None
+        assert c.in_reply_to_id is None
+
+    def test_pr_review_all_fields(self) -> None:
+        comment = PRReviewComment(name="u", content="c", created_at=1, updated_at=1)
+        r = PRReview(
+            review_id=10,
+            author="reviewer",
+            state="changes_requested",
+            body="Please fix",
+            comments=[comment],
+            created_at=1000,
+        )
+        assert r.review_id == 10
+        assert r.author == "reviewer"
+        assert r.state == "changes_requested"
+        assert r.body == "Please fix"
+        assert len(r.comments) == 1
+        assert r.created_at == 1000
+
+    def test_pr_review_minimal(self) -> None:
+        r = PRReview(author="u", created_at=0)
+        assert r.review_id is None
+        assert r.state == "commented"
+        assert r.body == ""
+        assert r.comments == []
+
+    def test_pr_file_has_reviews_and_workflow_status(self) -> None:
+        pr = PRFile(
+            pr_id=1,
+            repo="o/r",
+            status="open",
+            workflow_status="idle",
+            created_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+        assert pr.workflow_status == "idle"
+        assert pr.reviews == []
+        assert pr.last_review_ts is None
+
+    def test_pr_file_with_reviews(self) -> None:
+        review = PRReview(
+            review_id=1,
+            author="u",
+            state="commented",
+            body="text",
+            comments=[
+                PRReviewComment(
+                    comment_id=10,
+                    name="u",
+                    content="fix",
+                    path="a.py",
+                    line=5,
+                    created_at=100,
+                    updated_at=100,
+                )
+            ],
+            created_at=100,
+        )
+        pr = PRFile(
+            pr_id=2,
+            repo="o/r",
+            reviews=[review],
+            last_review_ts=100,
+            workflow_status="review_received",
+            created_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+        assert len(pr.reviews) == 1
+        assert pr.reviews[0].comments[0].path == "a.py"
+        assert pr.last_review_ts == 100
+        assert pr.workflow_status == "review_received"
+
+
+# ---------------------------------------------------------------------------
+# Store function tests
+# ---------------------------------------------------------------------------
+
+
+class TestPRStoreReviewFunctions:
+    """Tests for add_review, add_review_comment, set_pr_workflow_status,
+    list_prs_by_workflow_status."""
+
+    def test_add_review_creates_review_in_pr(self, tmp_path: Path) -> None:
+        set_pr_status(tmp_path, 10, "open", repo="o/r")
+        add_review(tmp_path, 10, review_id=1, author="user1", state="commented", body="Looks ok", created_at=500)
+        pr = load_pr(tmp_path, 10)
+        assert pr is not None
+        assert len(pr.reviews) == 1
+        assert pr.reviews[0].review_id == 1
+        assert pr.reviews[0].author == "user1"
+        assert pr.reviews[0].state == "commented"
+        assert pr.reviews[0].body == "Looks ok"
+        assert pr.workflow_status == "review_received"
+        assert pr.last_review_ts == 500
+
+    def test_add_review_updates_existing_review(self, tmp_path: Path) -> None:
+        set_pr_status(tmp_path, 11, "open", repo="o/r")
+        add_review(tmp_path, 11, review_id=1, author="u", state="commented", body="old", created_at=100)
+        add_review(tmp_path, 11, review_id=1, author="u", state="changes_requested", body="new", created_at=200)
+        pr = load_pr(tmp_path, 11)
+        assert pr is not None
+        assert len(pr.reviews) == 1
+        assert pr.reviews[0].state == "changes_requested"
+        assert pr.reviews[0].body == "new"
+
+    def test_add_review_when_pr_not_found_does_nothing(self, tmp_path: Path) -> None:
+        add_review(tmp_path, 999, review_id=1, author="u", state="commented", body="", created_at=0)
+        assert load_pr(tmp_path, 999) is None
+
+    def test_add_review_comment_creates_comment_in_review(self, tmp_path: Path) -> None:
+        set_pr_status(tmp_path, 20, "open", repo="o/r")
+        add_review(tmp_path, 20, review_id=1, author="u", state="commented", body="", created_at=100)
+        add_review_comment(
+            tmp_path,
+            20,
+            review_id=1,
+            comment_id=50,
+            author="u",
+            content="Fix this",
+            path="src/app.py",
+            line=10,
+            created_at=200,
+        )
+        pr = load_pr(tmp_path, 20)
+        assert pr is not None
+        assert len(pr.reviews) == 1
+        assert len(pr.reviews[0].comments) == 1
+        c = pr.reviews[0].comments[0]
+        assert c.comment_id == 50
+        assert c.content == "Fix this"
+        assert c.path == "src/app.py"
+        assert c.line == 10
+        assert pr.workflow_status == "review_received"
+        assert pr.last_review_ts == 200
+
+    def test_add_review_comment_creates_ad_hoc_review_when_no_match(self, tmp_path: Path) -> None:
+        set_pr_status(tmp_path, 21, "open", repo="o/r")
+        add_review_comment(
+            tmp_path,
+            21,
+            review_id=None,
+            comment_id=60,
+            author="u",
+            content="Issue here",
+            path="b.py",
+            line=5,
+            created_at=300,
+        )
+        pr = load_pr(tmp_path, 21)
+        assert pr is not None
+        assert len(pr.reviews) == 1
+        assert pr.reviews[0].review_id is None
+        assert len(pr.reviews[0].comments) == 1
+
+    def test_add_review_comment_updates_existing_comment(self, tmp_path: Path) -> None:
+        set_pr_status(tmp_path, 22, "open", repo="o/r")
+        add_review(tmp_path, 22, review_id=5, author="u", state="commented", body="", created_at=50)
+        add_review_comment(
+            tmp_path,
+            22,
+            review_id=5,
+            comment_id=70,
+            author="u",
+            content="Original",
+            path="c.py",
+            line=1,
+            created_at=100,
+        )
+        add_review_comment(
+            tmp_path,
+            22,
+            review_id=5,
+            comment_id=70,
+            author="u",
+            content="Edited",
+            path="c.py",
+            line=2,
+            created_at=200,
+        )
+        pr = load_pr(tmp_path, 22)
+        assert pr is not None
+        total_comments = sum(len(r.comments) for r in pr.reviews)
+        assert total_comments == 1
+        assert pr.reviews[0].comments[0].content == "Edited"
+
+    def test_add_review_comment_with_in_reply_to(self, tmp_path: Path) -> None:
+        set_pr_status(tmp_path, 23, "open", repo="o/r")
+        add_review_comment(
+            tmp_path,
+            23,
+            review_id=None,
+            comment_id=80,
+            author="u",
+            content="Reply",
+            path="d.py",
+            line=3,
+            created_at=400,
+            in_reply_to_id=50,
+        )
+        pr = load_pr(tmp_path, 23)
+        assert pr is not None
+        assert pr.reviews[0].comments[0].in_reply_to_id == 50
+
+    def test_add_review_comment_when_pr_not_found_does_nothing(self, tmp_path: Path) -> None:
+        add_review_comment(
+            tmp_path,
+            999,
+            review_id=None,
+            comment_id=1,
+            author="u",
+            content="x",
+            path="a.py",
+            line=1,
+            created_at=0,
+        )
+        assert load_pr(tmp_path, 999) is None
+
+    def test_set_pr_workflow_status(self, tmp_path: Path) -> None:
+        set_pr_status(tmp_path, 30, "open", repo="o/r")
+        set_pr_workflow_status(tmp_path, 30, "pending_plan")
+        pr = load_pr(tmp_path, 30)
+        assert pr is not None
+        assert pr.workflow_status == "pending_plan"
+
+    def test_set_pr_workflow_status_when_pr_not_found(self, tmp_path: Path) -> None:
+        set_pr_workflow_status(tmp_path, 999, "idle")
+        assert load_pr(tmp_path, 999) is None
+
+    def test_list_prs_by_workflow_status(self, tmp_path: Path) -> None:
+        set_pr_status(tmp_path, 40, "open", repo="o/r")
+        set_pr_status(tmp_path, 41, "open", repo="o/r")
+        set_pr_workflow_status(tmp_path, 40, "review_received")
+        result = list_prs_by_workflow_status(tmp_path, "review_received")
+        assert len(result) == 1
+        assert result[0][0] == 40
+
+    def test_list_prs_by_workflow_status_empty(self, tmp_path: Path) -> None:
+        assert list_prs_by_workflow_status(tmp_path, "review_received") == []
+
+    def test_pr_review_roundtrip_yaml(self, tmp_path: Path) -> None:
+        """Save a PR with reviews and load it back - verify all data persists."""
+        review = PRReview(
+            review_id=5,
+            author="reviewer",
+            state="changes_requested",
+            body="Please address",
+            comments=[
+                PRReviewComment(
+                    comment_id=100,
+                    name="reviewer",
+                    content="Fix indentation",
+                    path="main.py",
+                    line=15,
+                    created_at=1000,
+                    updated_at=1000,
+                    in_reply_to_id=None,
+                ),
+                PRReviewComment(
+                    comment_id=101,
+                    name="reviewer",
+                    content="Missing docstring",
+                    path="utils.py",
+                    line=3,
+                    created_at=1001,
+                    updated_at=1001,
+                ),
+            ],
+            created_at=1000,
+        )
+        pr = PRFile(
+            pr_id=50,
+            repo="o/r",
+            status="open",
+            workflow_status="review_received",
+            reviews=[review],
+            last_review_ts=1001,
+            created_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+        save_pr(tmp_path, pr)
+        loaded = load_pr(tmp_path, 50)
+        assert loaded is not None
+        assert loaded.workflow_status == "review_received"
+        assert loaded.last_review_ts == 1001
+        assert len(loaded.reviews) == 1
+        assert loaded.reviews[0].review_id == 5
+        assert loaded.reviews[0].state == "changes_requested"
+        assert len(loaded.reviews[0].comments) == 2
+        assert loaded.reviews[0].comments[0].path == "main.py"
+        assert loaded.reviews[0].comments[1].path == "utils.py"
+
+
+# ---------------------------------------------------------------------------
+# Webhook handler tests
+# ---------------------------------------------------------------------------
+
+
+def _make_review_config(tmp_path: Path) -> object:
+    config = type("Config", (), {})()
+    config.bot = type("Bot", (), {})()
+    config.bot.git_platform = "github"
+    config.bot.repository = "owner/repo"
+    config.bot.username = "coddybot"
+    config.bot.workspace_path = str(tmp_path)
+    config.github = type("GitHub", (), {"api_url": "https://api.github.com"})()
+    config.github_token_resolved = "token"
+    return config
+
+
+class TestWebhookPullRequestReview:
+    """Tests for pull_request_review event handler."""
+
+    def test_review_submitted_stores_in_pr(self, tmp_path: Path) -> None:
+        config = _make_review_config(tmp_path)
+        set_pr_status(tmp_path, 5, "open", repo="owner/repo")
+        payload = {
+            "action": "submitted",
+            "review": {
+                "id": 100,
+                "user": {"login": "reviewer1"},
+                "state": "changes_requested",
+                "body": "Fix these issues",
+                "submitted_at": "2024-06-01T12:00:00Z",
+            },
+            "pull_request": {"number": 5},
+            "repository": {"full_name": "owner/repo"},
+        }
+        handle_github_event(config, "pull_request_review", payload, repo_dir=tmp_path)
+        pr = load_pr(tmp_path, 5)
+        assert pr is not None
+        assert len(pr.reviews) == 1
+        assert pr.reviews[0].review_id == 100
+        assert pr.reviews[0].author == "reviewer1"
+        assert pr.reviews[0].state == "changes_requested"
+        assert pr.reviews[0].body == "Fix these issues"
+        assert pr.workflow_status == "review_received"
+
+    def test_review_submitted_ignores_bot_review(self, tmp_path: Path) -> None:
+        config = _make_review_config(tmp_path)
+        set_pr_status(tmp_path, 6, "open", repo="owner/repo")
+        payload = {
+            "action": "submitted",
+            "review": {
+                "id": 101,
+                "user": {"login": "coddybot"},
+                "state": "commented",
+                "body": "Self review",
+                "submitted_at": "2024-06-01T12:00:00Z",
+            },
+            "pull_request": {"number": 6},
+            "repository": {"full_name": "owner/repo"},
+        }
+        handle_github_event(config, "pull_request_review", payload, repo_dir=tmp_path)
+        pr = load_pr(tmp_path, 6)
+        assert pr is not None
+        assert len(pr.reviews) == 0
+
+    def test_review_submitted_ignores_other_repo(self, tmp_path: Path) -> None:
+        config = _make_review_config(tmp_path)
+        payload = {
+            "action": "submitted",
+            "review": {"id": 1, "user": {"login": "u"}, "state": "commented", "body": ""},
+            "pull_request": {"number": 1},
+            "repository": {"full_name": "other/repo"},
+        }
+        handle_github_event(config, "pull_request_review", payload, repo_dir=tmp_path)
+        assert load_pr(tmp_path, 1) is None
+
+    def test_review_submitted_ignores_non_submitted_action(self, tmp_path: Path) -> None:
+        config = _make_review_config(tmp_path)
+        set_pr_status(tmp_path, 7, "open", repo="owner/repo")
+        payload = {
+            "action": "dismissed",
+            "review": {"id": 1, "user": {"login": "u"}, "state": "commented", "body": ""},
+            "pull_request": {"number": 7},
+            "repository": {"full_name": "owner/repo"},
+        }
+        handle_github_event(config, "pull_request_review", payload, repo_dir=tmp_path)
+        pr = load_pr(tmp_path, 7)
+        assert pr is not None
+        assert len(pr.reviews) == 0
+
+    def test_review_submitted_creates_pr_if_missing(self, tmp_path: Path) -> None:
+        config = _make_review_config(tmp_path)
+        payload = {
+            "action": "submitted",
+            "review": {
+                "id": 200,
+                "user": {"login": "reviewer"},
+                "state": "commented",
+                "body": "Note",
+                "submitted_at": "2024-06-01T12:00:00Z",
+            },
+            "pull_request": {"number": 99},
+            "repository": {"full_name": "owner/repo"},
+        }
+        handle_github_event(config, "pull_request_review", payload, repo_dir=tmp_path)
+        pr = load_pr(tmp_path, 99)
+        assert pr is not None
+        assert len(pr.reviews) == 1
+
+
+class TestWebhookPullRequestReviewComment:
+    """Tests for pull_request_review_comment event handler."""
+
+    def test_review_comment_created_stores_in_pr(self, tmp_path: Path) -> None:
+        config = _make_review_config(tmp_path)
+        set_pr_status(tmp_path, 10, "open", repo="owner/repo")
+        payload = {
+            "action": "created",
+            "comment": {
+                "id": 500,
+                "user": {"login": "reviewer1"},
+                "body": "Rename this variable",
+                "path": "coddy/main.py",
+                "line": 42,
+                "pull_request_review_id": None,
+                "in_reply_to_id": None,
+                "created_at": "2024-06-01T12:00:00Z",
+                "updated_at": "2024-06-01T12:00:00Z",
+            },
+            "pull_request": {"number": 10},
+            "repository": {"full_name": "owner/repo"},
+        }
+        handle_github_event(config, "pull_request_review_comment", payload, repo_dir=tmp_path)
+        pr = load_pr(tmp_path, 10)
+        assert pr is not None
+        assert pr.workflow_status == "review_received"
+        all_comments = [c for r in pr.reviews for c in r.comments]
+        assert len(all_comments) == 1
+        assert all_comments[0].comment_id == 500
+        assert all_comments[0].content == "Rename this variable"
+        assert all_comments[0].path == "coddy/main.py"
+        assert all_comments[0].line == 42
+
+    def test_review_comment_edited_updates_content(self, tmp_path: Path) -> None:
+        config = _make_review_config(tmp_path)
+        set_pr_status(tmp_path, 11, "open", repo="owner/repo")
+        add_review(tmp_path, 11, review_id=50, author="u", state="commented", body="", created_at=100)
+        base = {
+            "pull_request": {"number": 11},
+            "repository": {"full_name": "owner/repo"},
+        }
+        handle_github_event(
+            config,
+            "pull_request_review_comment",
+            {
+                **base,
+                "action": "created",
+                "comment": {
+                    "id": 600,
+                    "user": {"login": "u"},
+                    "body": "Original",
+                    "path": "a.py",
+                    "line": 1,
+                    "pull_request_review_id": 50,
+                    "created_at": "2024-06-01T12:00:00Z",
+                },
+            },
+            repo_dir=tmp_path,
+        )
+        handle_github_event(
+            config,
+            "pull_request_review_comment",
+            {
+                **base,
+                "action": "edited",
+                "comment": {
+                    "id": 600,
+                    "user": {"login": "u"},
+                    "body": "Edited",
+                    "path": "a.py",
+                    "line": 2,
+                    "pull_request_review_id": 50,
+                    "created_at": "2024-06-01T12:00:00Z",
+                },
+            },
+            repo_dir=tmp_path,
+        )
+        pr = load_pr(tmp_path, 11)
+        assert pr is not None
+        all_comments = [c for r in pr.reviews for c in r.comments]
+        assert len(all_comments) == 1
+        assert all_comments[0].content == "Edited"
+
+    def test_review_comment_ignores_bot(self, tmp_path: Path) -> None:
+        config = _make_review_config(tmp_path)
+        set_pr_status(tmp_path, 12, "open", repo="owner/repo")
+        payload = {
+            "action": "created",
+            "comment": {
+                "id": 700,
+                "user": {"login": "coddybot"},
+                "body": "Auto reply",
+                "path": "a.py",
+                "line": 1,
+                "pull_request_review_id": None,
+                "created_at": "2024-06-01T12:00:00Z",
+            },
+            "pull_request": {"number": 12},
+            "repository": {"full_name": "owner/repo"},
+        }
+        handle_github_event(config, "pull_request_review_comment", payload, repo_dir=tmp_path)
+        pr = load_pr(tmp_path, 12)
+        assert pr is not None
+        assert len(pr.reviews) == 0
+
+    def test_review_comment_creates_pr_if_missing(self, tmp_path: Path) -> None:
+        config = _make_review_config(tmp_path)
+        payload = {
+            "action": "created",
+            "comment": {
+                "id": 800,
+                "user": {"login": "reviewer"},
+                "body": "Missing",
+                "path": "x.py",
+                "line": 5,
+                "pull_request_review_id": None,
+                "created_at": "2024-06-01T12:00:00Z",
+            },
+            "pull_request": {"number": 98},
+            "repository": {"full_name": "owner/repo"},
+        }
+        handle_github_event(config, "pull_request_review_comment", payload, repo_dir=tmp_path)
+        pr = load_pr(tmp_path, 98)
+        assert pr is not None
+
+    def test_review_comment_with_reply_to(self, tmp_path: Path) -> None:
+        config = _make_review_config(tmp_path)
+        set_pr_status(tmp_path, 13, "open", repo="owner/repo")
+        payload = {
+            "action": "created",
+            "comment": {
+                "id": 900,
+                "user": {"login": "reviewer"},
+                "body": "Clarification",
+                "path": "b.py",
+                "line": 3,
+                "pull_request_review_id": 50,
+                "in_reply_to_id": 800,
+                "created_at": "2024-06-01T12:00:00Z",
+            },
+            "pull_request": {"number": 13},
+            "repository": {"full_name": "owner/repo"},
+        }
+        handle_github_event(config, "pull_request_review_comment", payload, repo_dir=tmp_path)
+        pr = load_pr(tmp_path, 13)
+        assert pr is not None
+        all_comments = [c for r in pr.reviews for c in r.comments]
+        assert len(all_comments) == 1
+        assert all_comments[0].in_reply_to_id == 800
+
+
+class TestWebhookPRIssueComment:
+    """Tests for issue_comment on PR: user confirms review plan."""
+
+    def test_pr_comment_affirmative_sets_in_progress(self, tmp_path: Path) -> None:
+        config = _make_review_config(tmp_path)
+        set_pr_status(tmp_path, 15, "open", repo="owner/repo")
+        set_pr_workflow_status(tmp_path, 15, "waiting_confirmation")
+        payload = {
+            "action": "created",
+            "comment": {"body": "yes", "user": {"login": "user1"}},
+            "issue": {"number": 15, "pull_request": {"url": "..."}},
+            "repository": {"full_name": "owner/repo"},
+        }
+        handle_github_event(config, "issue_comment", payload, repo_dir=tmp_path)
+        pr = load_pr(tmp_path, 15)
+        assert pr is not None
+        assert pr.workflow_status == "in_progress"
+
+    def test_pr_comment_non_affirmative_does_not_change_status(self, tmp_path: Path) -> None:
+        config = _make_review_config(tmp_path)
+        set_pr_status(tmp_path, 16, "open", repo="owner/repo")
+        set_pr_workflow_status(tmp_path, 16, "waiting_confirmation")
+        payload = {
+            "action": "created",
+            "comment": {"body": "I have a question", "user": {"login": "user1"}},
+            "issue": {"number": 16, "pull_request": {"url": "..."}},
+            "repository": {"full_name": "owner/repo"},
+        }
+        handle_github_event(config, "issue_comment", payload, repo_dir=tmp_path)
+        pr = load_pr(tmp_path, 16)
+        assert pr is not None
+        assert pr.workflow_status == "waiting_confirmation"
+
+    def test_pr_comment_ignores_when_not_waiting_confirmation(self, tmp_path: Path) -> None:
+        config = _make_review_config(tmp_path)
+        set_pr_status(tmp_path, 17, "open", repo="owner/repo")
+        set_pr_workflow_status(tmp_path, 17, "idle")
+        payload = {
+            "action": "created",
+            "comment": {"body": "yes", "user": {"login": "user1"}},
+            "issue": {"number": 17, "pull_request": {"url": "..."}},
+            "repository": {"full_name": "owner/repo"},
+        }
+        handle_github_event(config, "issue_comment", payload, repo_dir=tmp_path)
+        pr = load_pr(tmp_path, 17)
+        assert pr is not None
+        assert pr.workflow_status == "idle"
+
+    def test_pr_comment_ignores_bot(self, tmp_path: Path) -> None:
+        config = _make_review_config(tmp_path)
+        set_pr_status(tmp_path, 18, "open", repo="owner/repo")
+        set_pr_workflow_status(tmp_path, 18, "waiting_confirmation")
+        payload = {
+            "action": "created",
+            "comment": {"body": "yes", "user": {"login": "coddybot"}},
+            "issue": {"number": 18, "pull_request": {"url": "..."}},
+            "repository": {"full_name": "owner/repo"},
+        }
+        handle_github_event(config, "issue_comment", payload, repo_dir=tmp_path)
+        pr = load_pr(tmp_path, 18)
+        assert pr is not None
+        assert pr.workflow_status == "waiting_confirmation"
+
+    def test_pr_comment_ignores_non_pr_issue(self, tmp_path: Path) -> None:
+        """issue_comment on a regular issue (not a PR) does not affect PR workflow."""
+        config = _make_review_config(tmp_path)
+        set_pr_status(tmp_path, 19, "open", repo="owner/repo")
+        set_pr_workflow_status(tmp_path, 19, "waiting_confirmation")
+        payload = {
+            "action": "created",
+            "comment": {"body": "yes", "user": {"login": "user1"}},
+            "issue": {"number": 19},
+            "repository": {"full_name": "owner/repo"},
+        }
+        handle_github_event(config, "issue_comment", payload, repo_dir=tmp_path)
+        pr = load_pr(tmp_path, 19)
+        assert pr is not None
+        assert pr.workflow_status == "waiting_confirmation"
+
+
+# ---------------------------------------------------------------------------
+# Idle timeout tests
+# ---------------------------------------------------------------------------
+
+
+class TestReviewIdleTimeout:
+    """Tests for run_review_idle_poll (observer poll for review_received)."""
+
+    def test_idle_timeout_transitions_to_pending_plan(self, tmp_path: Path) -> None:
+        set_pr_status(tmp_path, 50, "open", repo="o/r")
+        add_review(tmp_path, 50, review_id=1, author="u", state="commented", body="", created_at=100)
+        config = MagicMock()
+        run_review_idle_poll(config, tmp_path, idle_timeout=0)
+        pr = load_pr(tmp_path, 50)
+        assert pr is not None
+        assert pr.workflow_status == "pending_plan"
+
+    def test_idle_timeout_does_not_transition_when_not_expired(self, tmp_path: Path) -> None:
+        import time
+
+        set_pr_status(tmp_path, 51, "open", repo="o/r")
+        now = int(time.time())
+        add_review(tmp_path, 51, review_id=1, author="u", state="commented", body="", created_at=now)
+        config = MagicMock()
+        run_review_idle_poll(config, tmp_path, idle_timeout=9999)
+        pr = load_pr(tmp_path, 51)
+        assert pr is not None
+        assert pr.workflow_status == "review_received"
+
+    def test_idle_timeout_skips_non_review_received(self, tmp_path: Path) -> None:
+        set_pr_status(tmp_path, 52, "open", repo="o/r")
+        set_pr_workflow_status(tmp_path, 52, "idle")
+        config = MagicMock()
+        run_review_idle_poll(config, tmp_path, idle_timeout=0)
+        pr = load_pr(tmp_path, 52)
+        assert pr is not None
+        assert pr.workflow_status == "idle"
+
+    def test_idle_timeout_no_prs(self, tmp_path: Path) -> None:
+        config = MagicMock()
+        run_review_idle_poll(config, tmp_path, idle_timeout=0)
+
+
+# ---------------------------------------------------------------------------
+# Worker review processing tests
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerReviewProcessing:
+    """Tests for _process_pr_reviews, _collect_review_comments,
+    _build_review_plan in worker/run.py."""
+
+    def test_collect_review_comments_extracts_top_level_only(self) -> None:
+        from coddy.worker.run import _collect_review_comments
+
+        pr = PRFile(
+            pr_id=1,
+            repo="o/r",
+            reviews=[
+                PRReview(
+                    review_id=1,
+                    author="u",
+                    state="commented",
+                    comments=[
+                        PRReviewComment(
+                            comment_id=10,
+                            name="u",
+                            content="Fix",
+                            path="a.py",
+                            line=1,
+                            created_at=1,
+                            updated_at=1,
+                        ),
+                        PRReviewComment(
+                            comment_id=11,
+                            name="bot",
+                            content="Done",
+                            path="a.py",
+                            line=1,
+                            created_at=2,
+                            updated_at=2,
+                            in_reply_to_id=10,
+                        ),
+                    ],
+                    created_at=1,
+                ),
+            ],
+            created_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+        items = _collect_review_comments(pr)
+        assert len(items) == 1
+        assert items[0]["comment_id"] == 10
+        assert items[0]["path"] == "a.py"
+
+    def test_collect_review_comments_empty_reviews(self) -> None:
+        from coddy.worker.run import _collect_review_comments
+
+        pr = PRFile(
+            pr_id=1,
+            repo="o/r",
+            created_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+        assert _collect_review_comments(pr) == []
+
+    def test_build_review_plan_formats_markdown(self) -> None:
+        from coddy.worker.run import _build_review_plan
+
+        comments = [
+            {
+                "comment_id": 1,
+                "author": "user1",
+                "body": "Fix indentation",
+                "path": "src/main.py",
+                "line": 10,
+                "review_id": 1,
+            },
+            {
+                "comment_id": 2,
+                "author": "user2",
+                "body": "Missing docstring",
+                "path": "utils.py",
+                "line": None,
+                "review_id": 2,
+            },
+        ]
+        plan = _build_review_plan(comments)
+        assert "`src/main.py`" in plan
+        assert "line 10" in plan
+        assert "@user1" in plan
+        assert "Fix indentation" in plan
+        assert "`utils.py`" in plan
+        assert "file-level" in plan
+        assert "@user2" in plan
+
+    def test_process_pr_reviews_pending_plan(self, tmp_path: Path) -> None:
+        """Worker generates plan for PR with pending_plan and posts as PR comment."""
+        from coddy.config import AppConfig, BotConfig, LoggingConfig
+        from coddy.worker.run import _process_pr_reviews
+
+        set_pr_status(tmp_path, 60, "open", repo="owner/repo")
+        add_review(tmp_path, 60, review_id=1, author="u", state="commented", body="", created_at=100)
+        add_review_comment(
+            tmp_path,
+            60,
+            review_id=1,
+            comment_id=100,
+            author="u",
+            content="Fix this",
+            path="a.py",
+            line=5,
+            created_at=200,
+        )
+        set_pr_workflow_status(tmp_path, 60, "pending_plan")
+
+        config = AppConfig()
+        config.bot = BotConfig(
+            workspace_path=str(tmp_path),
+            repository="owner/repo",
+            username="coddybot",
+        )
+        config.logging = LoggingConfig()
+
+        mock_adapter = MagicMock()
+        mock_agent = MagicMock()
+        import logging
+
+        log = logging.getLogger("test")
+        did_work = _process_pr_reviews(config, tmp_path, mock_adapter, mock_agent, log)
+        assert did_work is True
+        mock_adapter.create_pr_comment.assert_called_once()
+        call_args = mock_adapter.create_pr_comment.call_args[0]
+        assert call_args[0] == "owner/repo"
+        assert call_args[1] == 60
+        assert "Review response plan" in call_args[2]
+        assert "Fix this" in call_args[2]
+
+        pr = load_pr(tmp_path, 60)
+        assert pr is not None
+        assert pr.workflow_status == "waiting_confirmation"
+
+    def test_process_pr_reviews_sets_idle_when_no_comments(self, tmp_path: Path) -> None:
+        """When PR has pending_plan but no review comments, set idle."""
+        from coddy.config import AppConfig, BotConfig, LoggingConfig
+        from coddy.worker.run import _process_pr_reviews
+
+        set_pr_status(tmp_path, 61, "open", repo="owner/repo")
+        set_pr_workflow_status(tmp_path, 61, "pending_plan")
+
+        config = AppConfig()
+        config.bot = BotConfig(
+            workspace_path=str(tmp_path),
+            repository="owner/repo",
+            username="coddybot",
+        )
+        config.logging = LoggingConfig()
+
+        import logging
+
+        log = logging.getLogger("test")
+        _process_pr_reviews(config, tmp_path, MagicMock(), MagicMock(), log)
+
+        pr = load_pr(tmp_path, 61)
+        assert pr is not None
+        assert pr.workflow_status == "idle"
+
+
+# ---------------------------------------------------------------------------
+# Review loop tests
+# ---------------------------------------------------------------------------
+
+
+class TestReviewLoop:
+    """Tests for run_review_loop_for_pr."""
+
+    def test_review_loop_no_comments_returns_success(self, tmp_path: Path) -> None:
+        from coddy.worker.review_loop import run_review_loop_for_pr
+
+        pr_file = PRFile(
+            pr_id=70,
+            repo="o/r",
+            created_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+        result = run_review_loop_for_pr(
+            adapter=MagicMock(),
+            agent=MagicMock(),
+            pr_file=pr_file,
+            repo="o/r",
+            repo_dir=tmp_path,
+        )
+        assert result == "success"
+
+    def test_review_loop_processes_comments_and_posts_replies(self, tmp_path: Path) -> None:
+        from coddy.worker.review_loop import run_review_loop_for_pr
+
+        pr_file = PRFile(
+            pr_id=71,
+            repo="o/r",
+            issue_id=10,
+            reviews=[
+                PRReview(
+                    review_id=1,
+                    author="u",
+                    state="commented",
+                    comments=[
+                        PRReviewComment(
+                            comment_id=200,
+                            name="u",
+                            content="Fix logic",
+                            path="app.py",
+                            line=10,
+                            created_at=100,
+                            updated_at=100,
+                        ),
+                    ],
+                    created_at=100,
+                ),
+            ],
+            created_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+
+        mock_adapter = MagicMock()
+        mock_pr = MagicMock()
+        mock_pr.head_branch = "71-feature"
+        mock_adapter.get_pr.return_value = mock_pr
+
+        mock_agent = MagicMock()
+        mock_agent.process_review_item.return_value = "Fixed the logic issue."
+
+        with patch("coddy.worker.review_loop.fetch_and_checkout_branch"):
+            with patch("coddy.worker.review_loop.set_commit_author"):
+                with patch("coddy.worker.review_loop.commit_all_and_push"):
+                    with patch("coddy.worker.review_loop.checkout_branch"):
+                        result = run_review_loop_for_pr(
+                            adapter=mock_adapter,
+                            agent=mock_agent,
+                            pr_file=pr_file,
+                            repo="o/r",
+                            repo_dir=tmp_path,
+                            bot_name="Bot",
+                            bot_email="bot@test.com",
+                            default_branch="main",
+                        )
+
+        assert result == "success"
+        mock_adapter.reply_to_review_comment.assert_called_once_with("o/r", 71, 200, "Fixed the logic issue.")
+
+    def test_review_loop_skips_reply_comments(self, tmp_path: Path) -> None:
+        """Comments with in_reply_to_id are skipped (they are replies, not top-level)."""
+        from coddy.worker.review_loop import run_review_loop_for_pr
+
+        pr_file = PRFile(
+            pr_id=72,
+            repo="o/r",
+            reviews=[
+                PRReview(
+                    review_id=1,
+                    author="u",
+                    state="commented",
+                    comments=[
+                        PRReviewComment(
+                            comment_id=300,
+                            name="bot",
+                            content="Reply",
+                            path="a.py",
+                            line=1,
+                            created_at=1,
+                            updated_at=1,
+                            in_reply_to_id=200,
+                        ),
+                    ],
+                    created_at=1,
+                ),
+            ],
+            created_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+
+        result = run_review_loop_for_pr(
+            adapter=MagicMock(),
+            agent=MagicMock(),
+            pr_file=pr_file,
+            repo="o/r",
+            repo_dir=tmp_path,
+        )
+        assert result == "success"
+
+    def test_review_loop_returns_failed_on_pr_fetch_error(self, tmp_path: Path) -> None:
+        from coddy.worker.review_loop import run_review_loop_for_pr
+
+        pr_file = PRFile(
+            pr_id=73,
+            repo="o/r",
+            reviews=[
+                PRReview(
+                    review_id=1,
+                    author="u",
+                    state="commented",
+                    comments=[
+                        PRReviewComment(
+                            comment_id=400,
+                            name="u",
+                            content="Fix",
+                            path="a.py",
+                            line=1,
+                            created_at=1,
+                            updated_at=1,
+                        ),
+                    ],
+                    created_at=1,
+                ),
+            ],
+            created_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+
+        mock_adapter = MagicMock()
+        mock_adapter.get_pr.side_effect = Exception("API error")
+
+        result = run_review_loop_for_pr(
+            adapter=mock_adapter,
+            agent=MagicMock(),
+            pr_file=pr_file,
+            repo="o/r",
+            repo_dir=tmp_path,
+        )
+        assert result == "failed"
+
+    def test_review_loop_reads_reply_from_file_when_agent_returns_none(self, tmp_path: Path) -> None:
+        from coddy.worker.review_loop import run_review_loop_for_pr
+        from coddy.worker.task_yaml import review_reply_file_path
+
+        pr_file = PRFile(
+            pr_id=74,
+            repo="o/r",
+            issue_id=10,
+            reviews=[
+                PRReview(
+                    review_id=1,
+                    author="u",
+                    state="commented",
+                    comments=[
+                        PRReviewComment(
+                            comment_id=500,
+                            name="u",
+                            content="Fix",
+                            path="a.py",
+                            line=1,
+                            created_at=1,
+                            updated_at=1,
+                        ),
+                    ],
+                    created_at=1,
+                ),
+            ],
+            created_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+
+        reply_path = review_reply_file_path(tmp_path, 74, 500)
+        reply_path.parent.mkdir(parents=True, exist_ok=True)
+        reply_path.write_text("body: File-based reply\n", encoding="utf-8")
+
+        mock_adapter = MagicMock()
+        mock_pr = MagicMock()
+        mock_pr.head_branch = "74-fix"
+        mock_adapter.get_pr.return_value = mock_pr
+
+        mock_agent = MagicMock()
+        mock_agent.process_review_item.return_value = None
+
+        with patch("coddy.worker.review_loop.fetch_and_checkout_branch"):
+            with patch("coddy.worker.review_loop.set_commit_author"):
+                with patch("coddy.worker.review_loop.commit_all_and_push"):
+                    with patch("coddy.worker.review_loop.checkout_branch"):
+                        result = run_review_loop_for_pr(
+                            adapter=mock_adapter,
+                            agent=mock_agent,
+                            pr_file=pr_file,
+                            repo="o/r",
+                            repo_dir=tmp_path,
+                            bot_name="Bot",
+                            bot_email="bot@test.com",
+                            default_branch="main",
+                        )
+
+        assert result == "success"
+        mock_adapter.reply_to_review_comment.assert_called_once_with("o/r", 74, 500, "File-based reply")


### PR DESCRIPTION
## PR Review Capability

Adds full PR review processing workflow: when a user submits a review with line-level comments on a PR created by the bot, the system stores the review data, waits for an idle timeout, generates a response plan, asks for user confirmation, and then applies fixes via the AI agent.

### What was done

**Schemas and storage**
- Added `PRReviewComment` and `PRReview` pydantic models in `coddy/services/store/schemas/pr_review.py`
- Extended `PRFile` with `reviews`, `workflow_status`, and `last_review_ts` fields
- Added `PR_WORKFLOW_STATUSES` (idle, review_received, pending_plan, waiting_confirmation, in_progress)
- Implemented store functions: `add_review`, `add_review_comment`, `set_pr_workflow_status`, `list_prs_by_workflow_status` in `pr_store.py`

**Webhook event handling**
- Added `_handle_pull_request_review` handler for `pull_request_review` (action=submitted) events
- Added `_handle_pull_request_review_comment` handler for `pull_request_review_comment` (action=created/edited) events
- Added `_handle_pr_issue_comment` to detect user confirmation on PR comments (affirmative reply sets workflow_status to in_progress)
- Bot's own reviews and comments are ignored

**Idle timeout and observer poll**
- Added `run_review_idle_poll` in `clarification_poll.py` - when no new review comments arrive within idle timeout, transitions PR from `review_received` to `pending_plan`
- Integrated into the observer poll loop in `run.py`

**Adapter methods**
- Added `reply_to_review_comment`, `create_pr_comment`, `list_pr_review_comments`, `get_pr_comments` to `GitPlatformAdapter` (base) and `GitHubAdapter`

**Worker review processing**
- Worker polls for PRs with `pending_plan` workflow_status, generates a review response plan, posts it as a PR comment, and sets `waiting_confirmation`
- On user confirmation (`in_progress`), runs `review_loop` - checks out PR branch, runs AI agent for each review comment, posts replies, commits and pushes
- Added `run_review_loop_for_pr` in `coddy/worker/review_loop.py`
- Added `_process_pr_reviews`, `_collect_review_comments`, `_build_review_plan` in `coddy/worker/run.py`

**Tests (48 new tests in `tests/test_pr_review.py`)**
- Schema tests for `PRReviewComment`, `PRReview`, `PRFile` with reviews
- Store function tests for `add_review`, `add_review_comment`, `set_pr_workflow_status`, `list_prs_by_workflow_status`, YAML roundtrip
- Webhook handler tests for `pull_request_review`, `pull_request_review_comment`, and PR issue comment confirmation
- Idle timeout tests for `run_review_idle_poll`
- Worker review processing tests for `_collect_review_comments`, `_build_review_plan`, `_process_pr_reviews`
- Review loop tests for `run_review_loop_for_pr` (success, failure, reply-from-file, skip replies, error handling)

### How to test

1. Run `pytest tests/ -v` - all 246 tests should pass
2. Run `ruff check coddy/ tests/` - no errors
3. For integration: create a PR via the bot, submit a review with line-level comments, wait for idle timeout, confirm the plan, and verify fixes are applied

### Workflow

1. User submits review on a PR (webhook: `pull_request_review` / `pull_request_review_comment`)
2. Review stored in `.coddy/pull_requests/open/{pr}.yaml`, workflow_status -> `review_received`
3. Observer idle poll: after timeout, workflow_status -> `pending_plan`
4. Worker generates plan, posts as PR comment, workflow_status -> `waiting_confirmation`
5. User replies "yes" (webhook: `issue_comment` on PR), workflow_status -> `in_progress`
6. Worker runs review loop: checkout PR branch, agent addresses each comment, replies posted, changes committed and pushed, workflow_status -> `idle`

Closes #25