### PR TITLE
Worker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Install system dependencies and Node.js 24 (Cursor agent needs Node 23.8+ for --use-system-ca)
 RUN apt update \
- && apt install -y --no-install-recommends git curl openssh-client ca-certificates gnupg \
+ && apt install -y --no-install-recommends git curl openssh-client ca-certificates gnupg procps \
  && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
  && apt install -y --no-install-recommends nodejs \
  && rm -rf /var/lib/apt/lists/* \
@@ -23,9 +23,6 @@ USER coddy
 RUN curl -fsSL https://cursor.com/install | bash
 ENV PATH="/home/coddy/.local/bin:${PATH}"
 
-# Health check for daemon (HTTP server on 8000)
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -sf http://localhost:8000/health || exit 1
-
 # Default: run daemon (webhook server). Override with "worker" in compose.
+# Healthcheck is defined per-service in docker-compose files.
 CMD ["python", "-m", "coddy", "observer"]

--- a/docker-compose.dist.yaml
+++ b/docker-compose.dist.yaml
@@ -28,6 +28,12 @@ services:
     ports:
       - "${CODDY_PORT:-8000}:8000"
     command: ["python", "-m", "coddy", "observer", "--config", "/app/config.yaml"]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      start_period: 5s
+      retries: 3
     <<: *shared-logs
 
   worker:
@@ -50,6 +56,12 @@ services:
       - ${REPO_PATH:-.}:/app/workspace:rw
       - ${CODDY_SSH_DIR:-${HOME}/.ssh}:/home/coddy/.ssh:ro
     command: ["python", "-m", "coddy", "worker", "--config", "/app/config.yaml"]
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f 'coddy worker' || exit 1"]
+      interval: 30s
+      timeout: 10s
+      start_period: 5s
+      retries: 3
     <<: *shared-logs
 
 secrets:


### PR DESCRIPTION
## Fix worker healthcheck (always unhealthy)

### Problem

The `Dockerfile` had a single `HEALTHCHECK` directive (`curl http://localhost:8000/health`) that only works for the observer (HTTP server on port 8000). The worker does not run an HTTP server, so its healthcheck always failed, resulting in `unhealthy` status in `docker compose ps`.

### Solution

Minimal fix (Variant 1 from the plan):

1. **Removed `HEALTHCHECK` from `Dockerfile`** - healthchecks are now defined per-service in docker-compose files, so each service gets an appropriate check
2. **Added `procps` package** to the Dockerfile `apt install` line (provides `pgrep`)
3. **Added explicit healthcheck for observer** in both `docker-compose.yml` and `docker-compose.dist.yaml` - uses `curl -sf http://localhost:8000/health` (same as the old Dockerfile check)
4. **Added explicit healthcheck for worker** in both compose files - uses `pgrep -f 'coddy worker'` to verify the worker process is running

### Changed files

- `Dockerfile` - removed `HEALTHCHECK` directive, added `procps` to apt install
- `docker-compose.yml` - added `healthcheck` sections for both observer and worker services
- `docker-compose.dist.yaml` - added `healthcheck` sections for both observer and worker services

### How to test

1. Rebuild the image: `docker compose build`
2. Start services: `docker compose up -d`
3. Wait ~30 seconds for healthchecks to run
4. Check status: `docker compose ps`
5. Both `coddy-observer` and `coddy-worker` should show `(healthy)` status

### Test results

- All 246 existing tests pass
- Pre-existing ruff E402 warnings (unrelated to this change) remain unchanged

Closes #31