### PR TITLE
Fix of plan in issue

### DIFF
--- a/coddy/observer/webhook/handlers.py
+++ b/coddy/observer/webhook/handlers.py
@@ -120,7 +120,8 @@ def _handle_issue_comment(
     log: logging.Logger,
 ) -> None:
     """On comment: created -> append; edited -> update; deleted -> set deleted_at.
-    If created + waiting_confirmation + affirmative -> on_user_confirmed."""
+    If created + waiting_confirmation or waiting_go + affirmative -> on_user_confirmed.
+    If created + waiting_confirmation + non-affirmative non-empty body -> pending_plan."""
     action = payload.get("action")
     if action not in ("created", "edited", "deleted"):
         return
@@ -179,6 +180,18 @@ def _handle_issue_comment(
                 )
             else:
                 log.warning("No GitHub token; cannot post reply")
+        elif (
+            issue_file
+            and issue_file.status == "waiting_confirmation"
+            and not is_affirmative_comment(body)
+            and body.strip()
+        ):
+            set_issue_status(repo_dir, int(issue_number), "pending_plan")
+            log.info(
+                "Issue #%s non-affirmative comment while waiting_confirmation, status -> pending_plan "
+                "(worker will rebuild plan)",
+                issue_number,
+            )
         return
 
     if action == "edited":
@@ -509,7 +522,8 @@ def handle_github_event(
     - pull_request_review (action=submitted): store review in PR file.
     - pull_request_review_comment (action=created/edited): store line comment in PR file.
     - issues (action=assigned): if bot is in assignees, set status pending_plan (worker builds plan).
-    - issue_comment: on user confirmation set issue status to queued; on PR comment check review confirmation.
+    - issue_comment: on user confirmation set issue status to queued; non-affirmative comment while
+      waiting_confirmation sets pending_plan; on PR comment check review confirmation.
     """
     logger = log or logging.getLogger("coddy.observer.webhook.handlers")
     work_dir = Path(repo_dir) if repo_dir is not None else _working_dir_from_config(config)

--- a/coddy/services/store/schemas/issue_file.py
+++ b/coddy/services/store/schemas/issue_file.py
@@ -57,7 +57,8 @@ class IssueFile(BaseModel):
     status: str = Field(
         default="pending_plan",
         description="Current state: pending_plan, waiting_confirmation, queued, in_progress, "
-        "waiting_user_reply, clarification_sent, user_replied, waiting_go, done, failed, closed",
+        "waiting_user_reply, clarification_sent, user_replied, waiting_go, done, failed, closed. "
+        "From waiting_confirmation, a non-affirmative user comment triggers pending_plan so the plan is rebuilt.",
     )
     title: str = Field(default="", description="Issue title")
     description: str = Field(default="", description="Issue description")

--- a/coddy/worker/agents/acp_agent.py
+++ b/coddy/worker/agents/acp_agent.py
@@ -285,10 +285,21 @@ class ACPAgent(AIAgent):
         return SufficiencyResult(sufficient=True)
 
     def generate_plan(self, issue: Issue, comments: List[Comment]) -> str | None:
+        recent = comments[-10:] if comments else []
+        thread_lines = [f"- {c.author}: {c.body}" for c in recent]
+        thread_block = "\n".join(thread_lines) if thread_lines else "(none)"
+        feedback_block = ""
+        if recent:
+            feedback_block = (
+                "The thread below may include user feedback on a previous plan. If so, revise the plan to "
+                "incorporate their feedback; do not repeat the previous plan verbatim.\n\n"
+                f"Recent thread (last up to 10 comments):\n{thread_block}\n\n"
+            )
         prompt = (
             "You are a planner. The user created an issue. Output ONLY a short implementation plan "
             "(bullet points, no code). Use the same language as the issue. "
             f"Issue title: {issue.title!r}\n\nBody:\n{issue.body or '(none)'}\n\n"
+            f"{feedback_block}"
             "Output only the plan, nothing else."
         )
         try:

--- a/tests/test_agents_acp.py
+++ b/tests/test_agents_acp.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
 
-from coddy.observer.models import Issue, ReviewComment
+from coddy.observer.models import Comment, Issue, ReviewComment
 
 
 def _issue(number: int = 42, body: str = "Enough body for sufficiency check.") -> Issue:
@@ -32,6 +32,26 @@ def test_acp_agent_generate_plan_returns_agent_text(tmp_path: Path) -> None:
         plan = agent.generate_plan(_issue(number=1), [])
 
     assert plan == "## Plan\n\n- Step 1\n- Step 2"
+
+
+def test_acp_agent_generate_plan_prompt_includes_thread_when_comments_present(tmp_path: Path) -> None:
+    """When comments exist, plan prompt asks to revise and lists recent
+    thread."""
+    from coddy.worker.agents.acp_agent import ACPAgent
+
+    agent = ACPAgent(command="agent", args=["acp"], timeout=30, working_directory=str(tmp_path))
+    now = datetime.now(UTC)
+    thread = [
+        Comment(id=1, body="Adjust section A", author="user1", created_at=now, updated_at=now),
+    ]
+
+    with patch.object(agent, "_run_prompt", return_value="- ok") as mock_run:
+        agent.generate_plan(_issue(number=2), thread)
+
+    prompt = mock_run.call_args[0][0]
+    assert "revise the plan" in prompt
+    assert "Recent thread" in prompt
+    assert "user1: Adjust section A" in prompt
 
 
 def test_acp_agent_generate_code_reads_pr_report(tmp_path: Path) -> None:

--- a/tests/test_webhook_handlers.py
+++ b/tests/test_webhook_handlers.py
@@ -598,3 +598,94 @@ def test_webhook_issue_comment_affirmative_sets_queued(tmp_path: Path) -> None:
     assert queued[0][1].repo == "owner/repo"
 
     mock_adapter.create_comment.assert_called_once()
+
+
+def test_webhook_issue_comment_non_affirmative_waiting_confirmation_sets_pending_plan(tmp_path: Path) -> None:
+    """On issue_comment with waiting_confirmation and non-affirmative body,
+    status -> pending_plan."""
+    from coddy.services.store import create_issue, set_issue_status
+
+    create_issue(tmp_path, 71, "owner/repo", "Fix plan flow", "Description", "user1")
+    set_issue_status(tmp_path, 71, "waiting_confirmation")
+
+    config = _issues_assigned_config(tmp_path)
+    config.github = type("GitHub", (), {"api_url": "https://api.github.com"})()
+    config.github_token_resolved = "gh-token"
+    payload = {
+        "action": "created",
+        "comment": {
+            "comment_id": 9001,
+            "body": "Please revise section 2 to use the store layer only.",
+            "user": {"login": "user1"},
+            "created_at": "2026-03-20T00:00:00Z",
+            "updated_at": "2026-03-20T00:00:00Z",
+        },
+        "issue": {"number": 71},
+        "repository": {"full_name": "owner/repo"},
+    }
+
+    handle_github_event(config, "issue_comment", payload, repo_dir=tmp_path)
+
+    issue = load_issue(tmp_path, 71)
+    assert issue is not None
+    assert issue.status == "pending_plan"
+    assert len(issue.comments) == 1
+    assert issue.comments[0].content.startswith("Please revise")
+
+
+def test_webhook_issue_comment_whitespace_only_waiting_confirmation_no_pending_plan(tmp_path: Path) -> None:
+    """Whitespace-only comment does not move waiting_confirmation to
+    pending_plan."""
+    from coddy.services.store import create_issue, set_issue_status
+
+    create_issue(tmp_path, 72, "owner/repo", "T", "B", "user1")
+    set_issue_status(tmp_path, 72, "waiting_confirmation")
+
+    config = _issues_assigned_config(tmp_path)
+    payload = {
+        "action": "created",
+        "comment": {
+            "comment_id": 9002,
+            "body": "   \n\t  ",
+            "user": {"login": "user1"},
+            "created_at": "2026-03-20T00:00:00Z",
+            "updated_at": "2026-03-20T00:00:00Z",
+        },
+        "issue": {"number": 72},
+        "repository": {"full_name": "owner/repo"},
+    }
+
+    handle_github_event(config, "issue_comment", payload, repo_dir=tmp_path)
+
+    issue = load_issue(tmp_path, 72)
+    assert issue is not None
+    assert issue.status == "waiting_confirmation"
+
+
+def test_webhook_issue_comment_waiting_go_non_affirmative_does_not_set_pending_plan(tmp_path: Path) -> None:
+    """Non-affirmative comment on waiting_go does not set pending_plan (plan
+    confirmation scope only)."""
+    from coddy.services.store import create_issue, set_issue_status
+
+    create_issue(tmp_path, 73, "owner/repo", "T", "B", "user1")
+    set_issue_status(tmp_path, 73, "waiting_go")
+
+    config = _issues_assigned_config(tmp_path)
+    payload = {
+        "action": "created",
+        "comment": {
+            "comment_id": 9003,
+            "body": "Change the approach before I say go",
+            "user": {"login": "user1"},
+            "created_at": "2026-03-20T00:00:00Z",
+            "updated_at": "2026-03-20T00:00:00Z",
+        },
+        "issue": {"number": 73},
+        "repository": {"full_name": "owner/repo"},
+    }
+
+    handle_github_event(config, "issue_comment", payload, repo_dir=tmp_path)
+
+    issue = load_issue(tmp_path, 73)
+    assert issue is not None
+    assert issue.status == "waiting_go"

--- a/tests/test_worker_run.py
+++ b/tests/test_worker_run.py
@@ -1,7 +1,7 @@
 """Tests for worker run (queue polling, assignment-only filtering)."""
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from coddy.config import AppConfig, BotConfig, LoggingConfig, load_config
 from coddy.services.store import create_issue, load_issue, set_issue_status
@@ -50,7 +50,8 @@ def test_worker_processes_only_issues_assigned_to_bot_when_assignment_only(tmp_p
     set_issue_status(tmp_path, 2, "queued")
 
     config = _make_config(tmp_path, assignment_only=True, username="coddybot")
-    run_worker(config, once=True)
+    with patch.object(AppConfig, "github_token_resolved", PropertyMock(return_value=None)):
+        run_worker(config, once=True)
 
     # Issue 1 (coddybot) should be processed: report written, status done
     issue1 = load_issue(tmp_path, 1)
@@ -81,7 +82,8 @@ def test_worker_processes_any_queued_issue_when_assignment_only_false(tmp_path: 
     set_issue_status(tmp_path, 3, "queued")
 
     config = _make_config(tmp_path, assignment_only=False, username="coddybot")
-    run_worker(config, once=True)
+    with patch.object(AppConfig, "github_token_resolved", PropertyMock(return_value=None)):
+        run_worker(config, once=True)
 
     issue3 = load_issue(tmp_path, 3)
     assert issue3 is not None


### PR DESCRIPTION
## Fix plan revision when user comments during waiting_confirmation

### What was done

1. **Webhook (`coddy/observer/webhook/handlers.py`)** - After saving a new issue comment, if the issue is in `waiting_confirmation` and the comment is not affirmative (`is_affirmative_comment`) but has non-whitespace body, the status is set to `pending_plan` so the worker regenerates the plan. Affirmative comments still call `on_user_confirmed` first. `waiting_go` is unchanged for non-affirmative comments (no transition to `pending_plan`).

2. **ACP planner (`coddy/worker/agents/acp_agent.py`)** - `generate_plan` now includes the last up to 10 issue comments in the prompt and instructs the model to revise the plan when the thread contains feedback, instead of repeating the previous plan.

3. **Schema (`coddy/services/store/schemas/issue_file.py`)** - Documented the `waiting_confirmation` → `pending_plan` transition in the `status` field description.

4. **Tests** - Added webhook integration tests for `pending_plan` transition, whitespace-only comment, and `waiting_go` unchanged. Added ACP test for prompt content with comments. Stabilized worker queue tests by patching `AppConfig.github_token_resolved` so dry-run does not depend on `GITHUB_TOKEN` in the environment.

### How to test

1. Run the test suite: `pytest tests/ -v`
2. Manual flow: put an issue in `waiting_confirmation`, post a non-affirmative comment (e.g. "Change section 2") - store should show `pending_plan`; worker should regenerate plan; observer poll should post the new plan and return to `waiting_confirmation`.

Closes #35